### PR TITLE
Isolated CUDA and Vulkan support into items that can be configured with environment variables

### DIFF
--- a/Sources/SwiftRT/device/DeviceDeepFunctions.swift
+++ b/Sources/SwiftRT/device/DeviceDeepFunctions.swift
@@ -16,6 +16,12 @@
 import Foundation
 
 //==============================================================================
+/// NanPropagation
+public enum NanPropagation: Int, Codable {
+    case propagate, noPropagate
+}
+
+//==============================================================================
 /// Convolution
 ///
 public class ConvolutionInferring<T> where
@@ -35,6 +41,7 @@ public class ConvolutionTraining<T>: ConvolutionInferring<T> where
     { fatalError("Abstract") }
 }
 
+#if canImport(CCuda)
 public extension DeviceQueue {
     func createConvolutionInferring<T>(
         x: T,
@@ -106,6 +113,7 @@ public extension CudaQueue {
         fatalError("cpu not implemented")
     }
 }
+#endif
 
 //==============================================================================
 // ConvolutionProperties
@@ -228,6 +236,7 @@ public extension DeviceQueue {
     }
 }
 
+#if canImport(CCuda)
 public extension CudaQueue {
     func createActivation<T>(
         x: T,
@@ -241,6 +250,7 @@ public extension CudaQueue {
                                            nan: nan, reluCeiling: reluCeiling)
     }
 }
+#endif
 
 //==============================================================================
 public enum TransposeOp: Int, Codable {

--- a/Sources/SwiftRT/device/Platform.swift
+++ b/Sources/SwiftRT/device/Platform.swift
@@ -61,15 +61,19 @@ final public class Platform: LocalPlatform {
         return Platform.local.services[cpuServiceName]!.devices[0]
     }()
 
+    #if canImport(CCuda)
     // shortcut to cuda sercoe
     public static var cuda: CudaService? = {
         return Platform.local.services[cudaServiceName] as? CudaService
     }()
+    #endif
     
+    #if canImport(CVulkan)
     // shortcut to vulkan service
     public static var vulkan: VulkanService? = {
         return Platform.local.services[vulkanServiceName] as? VulkanService
     }()
+    #endif
 
     //--------------------------------------------------------------------------
     // these are to aid unit tests

--- a/Sources/SwiftRT/device/cuda/CudaDevice.swift
+++ b/Sources/SwiftRT/device/cuda/CudaDevice.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 import Foundation
+
+#if canImport(CCuda)
 import CCuda
 
 public class CudaDevice : LocalComputeDevice {
@@ -136,3 +138,5 @@ public class CudaDevice : LocalComputeDevice {
 		try cudaCheck(status: cudaSetDevice(Int32(id)))
 	}
 }
+
+#endif

--- a/Sources/SwiftRT/device/cuda/CudaDeviceArray.swift
+++ b/Sources/SwiftRT/device/cuda/CudaDeviceArray.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 import Foundation
+
+#if canImport(CCuda)
 import CCuda
 
 public class CudaDeviceArray : DeviceArray {
@@ -77,3 +79,5 @@ public class CudaDeviceArray : DeviceArray {
 		}
 	}
 }
+
+#endif

--- a/Sources/SwiftRT/device/cuda/CudaQueue.swift
+++ b/Sources/SwiftRT/device/cuda/CudaQueue.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 import Foundation
+
+#if canImport(CCuda)
 import CCuda
 
 //import CudaKernels
@@ -416,3 +418,5 @@ public final class CudaReductionContext: ReductionContext {
                          zero: false)
     }
 }
+
+#endif

--- a/Sources/SwiftRT/device/cuda/CudaQueueEvent.swift
+++ b/Sources/SwiftRT/device/cuda/CudaQueueEvent.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 import Foundation
+
+#if canImport(CCuda)
 import CCuda
 
 public final class CudaQueueEvent : QueueEvent {
@@ -83,3 +85,5 @@ public final class CudaQueueEvent : QueueEvent {
         }
     }
 }
+
+#endif

--- a/Sources/SwiftRT/device/cuda/CudaService.swift
+++ b/Sources/SwiftRT/device/cuda/CudaService.swift
@@ -14,6 +14,15 @@
 // limitations under the License.
 //
 import Foundation
+
+//==============================================================================
+/// a set of predefined property names to simplify configuring
+/// the service properties
+public enum CudaPropertyKey: Int {
+    case queuesPerDevice
+}
+
+#if canImport(CCuda)
 import CCuda
 
 //==============================================================================
@@ -90,14 +99,6 @@ public final class CudaService: LocalComputeService {
     deinit {
         ObjectTracker.global.remove(trackingId: trackingId)
     }
-}
-
-
-//==============================================================================
-/// a set of predefined property names to simplify configuring
-/// the service properties
-public enum CudaPropertyKey: Int {
-    case queuesPerDevice
 }
 
 //==============================================================================
@@ -194,12 +195,6 @@ public func curandGetErrorString(_ status: curandStatus_t) -> String {
 /// ReductionOp
 public enum ReductionOp: Int, Codable {
     case add, mul, min, max, amax, avg, norm1, norm2
-}
-
-//==============================================================================
-/// NanPropagation
-public enum NanPropagation: Int, Codable {
-    case propagate, noPropagate
 }
 
 //==============================================================================
@@ -762,3 +757,5 @@ public final class ReductionTensorDescriptor : ObjectTracking {
         ObjectTracker.global.remove(trackingId: trackingId)
 	}
 }
+
+#endif

--- a/Sources/SwiftRT/device/cuda/intrinsics/CudaActivation.swift
+++ b/Sources/SwiftRT/device/cuda/intrinsics/CudaActivation.swift
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+#if canImport(CCuda)
 import CCuda
 
 //==============================================================================
@@ -123,3 +125,4 @@ extension ActivationMode {
     }
 }
 
+#endif

--- a/Sources/SwiftRT/device/cuda/intrinsics/CudaBatchNormalize.swift
+++ b/Sources/SwiftRT/device/cuda/intrinsics/CudaBatchNormalize.swift
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+#if canImport(CCuda)
 import CCuda
 
 public struct CudaBatchNormalize<T> where
@@ -170,3 +172,5 @@ extension BatchNormalizeMode {
         }
     }
 }
+
+#endif

--- a/Sources/SwiftRT/device/cuda/intrinsics/CudaConvolution.swift
+++ b/Sources/SwiftRT/device/cuda/intrinsics/CudaConvolution.swift
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+#if canImport(CCuda)
 import CCuda
 
 //==============================================================================
@@ -757,3 +759,4 @@ extension ConvolutionMode {
     }
 }
 
+#endif

--- a/Sources/SwiftRT/device/cuda/intrinsics/CudaDense.swift
+++ b/Sources/SwiftRT/device/cuda/intrinsics/CudaDense.swift
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+#if canImport(CCuda)
 import CCuda
 
 public class CudaDense<T> where
@@ -141,3 +143,5 @@ public class CudaDense<T> where
         }
     }
 }
+
+#endif

--- a/Sources/SwiftRT/device/cuda/intrinsics/CudaIntrinsics.swift
+++ b/Sources/SwiftRT/device/cuda/intrinsics/CudaIntrinsics.swift
@@ -15,6 +15,8 @@
 //
 import Foundation
 
+#if canImport(CCuda)
+
 public extension CudaQueue {
     //--------------------------------------------------------------------------
     /// abs
@@ -395,3 +397,5 @@ public extension CudaQueue {
     {
     }
 }
+
+#endif

--- a/Sources/SwiftRT/device/cuda/intrinsics/CudaPooling.swift
+++ b/Sources/SwiftRT/device/cuda/intrinsics/CudaPooling.swift
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+#if canImport(CCuda)
 import CCuda
 
 // *** TODO design questions!
@@ -129,3 +131,5 @@ extension PoolingMode {
         }
     }
 }
+
+#endif

--- a/Sources/SwiftRT/device/cuda/intrinsics/CudaSoftmax.swift
+++ b/Sources/SwiftRT/device/cuda/intrinsics/CudaSoftmax.swift
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+#if canImport(CCuda)
 import CCuda
 
 // *** TODO design questions!
@@ -120,3 +122,5 @@ extension SoftmaxMode {
         }
     }
 }
+
+#endif

--- a/Sources/SwiftRT/device/vulkan/Errors.swift
+++ b/Sources/SwiftRT/device/vulkan/Errors.swift
@@ -13,8 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import CVulkan
 
+#if canImport(CVulkan)
+import CVulkan
 
 //==============================================================================
 // vkCheck
@@ -76,3 +77,5 @@ private let errorStrings = [
     // VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR = VK_ERROR_INVALID_EXTERNAL_HANDLE,
     // VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR: "VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR",
 ]
+
+#endif

--- a/Sources/SwiftRT/device/vulkan/Memory.swift
+++ b/Sources/SwiftRT/device/vulkan/Memory.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 import Foundation
+
+#if canImport(CVulkan)
 import CVulkan
 
 //==============================================================================
@@ -66,3 +68,5 @@ extension LocalComputeDevice {
         fatalError()
     }
 }
+
+#endif

--- a/Sources/SwiftRT/device/vulkan/VulkanDevice.swift
+++ b/Sources/SwiftRT/device/vulkan/VulkanDevice.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 import Foundation
+
+#if canImport(CVulkan)
 import CVulkan
 
 public class VulkanDevice : LocalComputeDevice {
@@ -141,3 +143,5 @@ public extension DeviceLimits {
         maxMemoryAllocationCount = Int(limits.maxMemoryAllocationCount)
     }
 }
+
+#endif

--- a/Sources/SwiftRT/device/vulkan/VulkanProperties.swift
+++ b/Sources/SwiftRT/device/vulkan/VulkanProperties.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 import Foundation
+
+#if canImport(CVulkan)
 import CVulkan
 
 //==============================================================================
@@ -29,3 +31,4 @@ public let VK_API_VERSION_1_0 = VK_MAKE_VERSION(1, 0, 0)
 // Vulkan 1.1 version number
 public let VK_API_VERSION_1_1 = VK_MAKE_VERSION(1, 1, 0)
 
+#endif

--- a/Sources/SwiftRT/device/vulkan/VulkanService.swift
+++ b/Sources/SwiftRT/device/vulkan/VulkanService.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 import Foundation
+
+#if canImport(CVulkan)
 import CVulkan
 
 //==============================================================================
@@ -293,3 +295,5 @@ public enum VulkanPropertyKey: Int {
     case engineVersion
     case apiVersion
 }
+
+#endif

--- a/Tests/SwiftRTTests/test_Syntax.swift
+++ b/Tests/SwiftRTTests/test_Syntax.swift
@@ -15,7 +15,10 @@
 //
 import XCTest
 import Foundation
+
+#if canImport(CVulkan)
 import CVulkan
+#endif
 
 @testable import SwiftRT
 
@@ -59,6 +62,7 @@ class test_Syntax: XCTestCase {
     // sets properties in the Platform `serviceProperties` dictionary
     // to be used during compute service initialization
     func test_setServiceProperties() {
+        #if canImport(CVulkan)
         Platform.log.level = .diagnostic
         Platform.log.categories = [.properties]
         Platform.local.servicePriority = [vulkanServiceName]
@@ -77,6 +81,7 @@ class test_Syntax: XCTestCase {
         } catch {
             XCTFail(String(describing: error))
         }
+        #endif
     }
     
     //==========================================================================


### PR DESCRIPTION
This lets you selectively build either CUDA or Vulkan support (or both) through the use of local environment variables. To do this, you can use something like 

```
export SWIFTRT_ENABLE_CUDA=1
```

or 

```
export SWIFTRT_ENABLE_VULKAN=1
```

to enable the compilation of the system libraries and code required to use either accelerator. This should be extensible to other accelerators in the future, and allows for combinations of accelerators in a single instance of the library.

By default, this builds a CPU-only version of SwiftRT if no environment variables are set, and that should build and test cleanly with these changes.