### PR TITLE
Fix `Differentiable` conformance and define derivative stubs.

### DIFF
--- a/Sources/SwiftRT/common/AnyScalar.swift
+++ b/Sources/SwiftRT/common/AnyScalar.swift
@@ -612,15 +612,12 @@ extension Double : AnyFloatingPoint {
     }
 }
 
+//==============================================================================
+/// AnyDifferentiableScalar
+///
+// NOTE: This is similar to `TensorFlowFloatingPoint`:
+// https://github.com/tensorflow/swift-apis/blob/d056376170211a45249f82dfac8e1bc57dce1b74/Sources/TensorFlow/Core/DataTypes.swift#L84
 
-
-
-
-
-
-
-
-
-
-
-
+public protocol AnyDifferentiableScalar: Differentiable & FloatingPoint & AnyConvertable where
+    Self == TangentVector {}
+extension Float: AnyDifferentiableScalar {}

--- a/Sources/SwiftRT/common/AnyScalar.swift
+++ b/Sources/SwiftRT/common/AnyScalar.swift
@@ -615,9 +615,11 @@ extension Double : AnyFloatingPoint {
 //==============================================================================
 /// AnyDifferentiableScalar
 ///
+/// Marker protocol for `Differentiable`-conforming scalar types.
+///
 // NOTE: This is similar to `TensorFlowFloatingPoint`:
 // https://github.com/tensorflow/swift-apis/blob/d056376170211a45249f82dfac8e1bc57dce1b74/Sources/TensorFlow/Core/DataTypes.swift#L84
 
-public protocol AnyDifferentiableScalar: Differentiable & FloatingPoint & AnyConvertable where
+public protocol AnyDifferentiableScalar: Differentiable & FloatingPoint & AnyElement where
     Self == TangentVector {}
 extension Float: AnyDifferentiableScalar {}

--- a/Sources/SwiftRT/operators/ElementWise.swift
+++ b/Sources/SwiftRT/operators/ElementWise.swift
@@ -618,3 +618,85 @@ public extension CpuAsynchronousQueue {
     }
 }
 #endif
+
+//==============================================================================
+/// Derivative registration
+
+@differentiating(maximum)
+@inlinable @inline(__always)
+func vjpMaximum<T>(_ lhs: T, _ rhs: T) -> (
+    value: T, pullback: (T) -> (T, T)
+) where
+    T: DifferentiableTensorView
+{
+    let value = maximum(lhs, rhs)
+    // FIXME: Implement pullback.
+    return (value, { v in fatalError() })
+}
+
+@differentiating(maximum)
+@inlinable @inline(__always)
+func vjpMaximum<T>(_ lhs: T, _ rhs: T.Element) -> (
+    value: T, pullback: (T) -> (T, T.Element)
+) where
+    T: DifferentiableTensorView
+{
+    let value = maximum(lhs, rhs)
+    // FIXME: Implement pullback.
+    return (value, { v in fatalError() })
+}
+
+@differentiating(maximum)
+@inlinable @inline(__always)
+func vjpMaximum<T>(_ lhs: T.Element, _ rhs: T) -> (
+    value: T, pullback: (T) -> (T.Element, T)) where
+    T: DifferentiableTensorView
+{
+    let value = maximum(lhs, rhs)
+    // FIXME: Implement pullback.
+    return (value, { v in fatalError() })
+}
+
+@differentiating(minimum)
+@inlinable @inline(__always)
+func vjpMinimum<T>(_ lhs: T, _ rhs: T) -> (
+    value: T, pullback: (T) -> (T, T)
+) where
+    T: DifferentiableTensorView
+{
+    let value = minimum(lhs, rhs)
+    // FIXME: Implement pullback.
+    return (value, { v in fatalError() })
+}
+
+@differentiating(minimum)
+@inlinable @inline(__always)
+func vjpMinimum<T>(_ lhs: T, _ rhs: T.Element) -> (
+    value: T, pullback: (T) -> (T, T.Element)
+) where
+    T: DifferentiableTensorView
+{
+    let value = minimum(lhs, rhs)
+    // FIXME: Implement pullback.
+    return (value, { v in fatalError() })
+}
+
+@differentiating(minimum)
+@inlinable @inline(__always)
+func vjpMinimum<T>(_ lhs: T.Element, _ rhs: T) -> (
+    value: T, pullback: (T) -> (T.Element, T)
+) where
+    T: DifferentiableTensorView
+{
+    let value = minimum(lhs, rhs)
+    // FIXME: Implement pullback.
+    return (value, { v in fatalError() })
+}
+
+extension TensorView where Self: DifferentiableTensorView {
+    @differentiating(squared)
+    @inlinable @inline(__always)
+    func vjpSquared() -> (value: Self, pullback: (Self) -> (Self)) {
+        return (squared(), { v in v * (self + self) })
+    }
+}

--- a/Sources/SwiftRT/operators/Reductions.swift
+++ b/Sources/SwiftRT/operators/Reductions.swift
@@ -531,3 +531,15 @@ public extension TensorView where Element: Real {
         return result
     }
 }
+
+//==============================================================================
+/// Derivative registration
+
+public extension TensorView where Self: DifferentiableTensorView {
+    @differentiating(mean)
+    @inlinable @inline(__always)
+    func vjpMean() -> (value: Self, pullback: (Self) -> (Self)) {
+        // FIXME: Implement pullback.
+        return (mean(), { v in fatalError() })
+    }
+}

--- a/Sources/SwiftRT/tensor/TensorView.swift
+++ b/Sources/SwiftRT/tensor/TensorView.swift
@@ -44,7 +44,7 @@ public protocol Differentiable {}
 ///
 /// Data repeating (broadcasting) is an instrinsic feature
 ///
-public protocol TensorView: Differentiable, Logging {
+public protocol TensorView: Logging {
     //--------------------------------------------------------------------------
     /// the type of element stored by the tensor
     associatedtype Element
@@ -143,6 +143,17 @@ public extension TensorView {
         }
     }
 }
+
+//==============================================================================
+/// DifferentiableTensorView
+///
+/// Marker protocol for `TensorView` that conform to `Differentiable`.
+///
+/// While this protoocl is not strictly necessary, it is used to reduce the
+/// number of generic requirements when writing `@differentiable` attributes on
+/// generic differentiable `TensorView` functions.
+public protocol DifferentiableTensorView: TensorView & Differentiable where
+    Self == TangentVector, Element: AnyDifferentiableScalar {}
 
 //==============================================================================
 // view subscripting helpers


### PR DESCRIPTION
Fix `TensorView: Differentiable` conformance and define derivative function stubs.

- Remove unconditional `TensorView: Differentiable` conformance.
  - It does not make sense for `TensorView` to unconditionally conform to
    `Differentiable`: only a tensor of `Differentiable`-conforming elements is
    differentiable. For example, a `TensorView`-conforming type with
    `Element = Int` should not conform to `Differentiable`.
  - Remove ifdef'd `@noDerivative` code.
- Add auxiliary protocols for differentiation.
  - `AnyDifferentiableScalar` is a marker protocol for all
    `Differentiable`-conforming scalar types. It cannot be a typealias because
    typealiases do not support `where` clauses.
  - `DifferentiableTensorView` is a marker protocol for all
    types conforming to `Differentiable` and `TensorView`.
    - It is not possible to conditionally refine protocols:
      `extension TensorView: Differentiable where Element: AnyDifferentiableScalar`.
  - These marker protocols are not strictly needed, but help reduce the
    number of generic requirements when writing `@differentiable` attributes
    on generic differentiable `TensorView` functions.
    https://github.com/tensorflow/swift-apis adopts the same approach:
    the [`TensorFlowFloatingPoint`](https://github.com/tensorflow/swift-apis/blob/f24d1a2ce3a27740086b12caf24dcadae4669176/Sources/TensorFlow/Core/DataTypes.swift#L84) protocol is analogous to
    `AnyDifferentiableScalar`.
- Add conditional `Vector: DifferentiableTensorView` conformance.
  - `Vector.TangentVector` is `Vector`.
- Register derivatives for `TensorView` operations.
  - I registered the minimal set of VJPs for the case study to compile.
  - Unimplemented pullback functions (returned by VJPs) are marked with `FIXME`.
  - VJPs are not tested.
- Orthogonal: change `TensorView` to define `+` and `-` when `Element`
  conforms to `AdditiveArithmetic` instead of `Numeric`. This follows the
  practice of "using least constrained requirements" to enable maximum
  code reuse in protocol-oriented programming.

Todos:
- Implement currently unimplemented pullback functions.
- Add derivative correctness tests.
- Add conditional conformances to `DifferentiableTensorView` for more `TensorView`-conforming types, e.g. `Matrix`.

---

Tested with the `tensorflow-DEVELOPMENT-2019-11-15-a` macOS toolchain.