### PR TITLE
Fix `TensorView._vjpInit`.

### DIFF
--- a/Sources/SwiftRT/tensor/Initialization.swift
+++ b/Sources/SwiftRT/tensor/Initialization.swift
@@ -174,10 +174,10 @@ public extension TensorView {
 
 //==============================================================================
 //
+
 public extension TensorView where Self: DifferentiableTensorView {
-    //
-    func _vjpInit(repeating value: Element, to extents: [Int], name: String?) ->
-        (value: Self, pullback: (Self) -> (Element, [Int], String?))
+    static func _vjpInit(repeating value: Element, to extents: [Int], name: String?) ->
+        (value: Self, pullback: (Self) -> (Element))
     {
         fatalError()
     }


### PR DESCRIPTION
Fix `TensorView._vjpInit(repeating: Element, to: [Int], name: String?)`.

- `_vjpInit` should be a static function, to match the type context of the
  original function (`init`).
- The pullback returned by `_vjpInit` should return only the `TangentVector`
  types corresponding to the `wrt` parameters of the
  `@differentiable(vjp: _vjpInit, ...)` attribute.
  - When the original attribute does not explicitly specify a `wrt` clause,
    the `wrt` parameters are inferred to be the ones that conform to
    `Differentiable` (taking into account the `@differentiable` attribute
    `where` clause requirements, if specified).

---

Resolves the error:
```
swiftrt/Sources/SwiftRT/tensor/Initialization.swift:75:26: error: '_vjpInit' does not have expected type '<Self where Self : DifferentiableTensorView> (Self.Type) -> (Self.Element, [Int], String?) -> (Self, (Self.TangentVector) -> Self.Element.TangentVector)'
    @differentiable(vjp: _vjpInit where Self: DifferentiableTensorView)
                         ^
```