### PR TITLE
[AutoDiff] Use `@_semantics("autodiff.nonvarying")`.

### DIFF
--- a/Sources/SwiftRT/tensor/Ranges.swift
+++ b/Sources/SwiftRT/tensor/Ranges.swift
@@ -52,6 +52,7 @@ public protocol PartialRangeExpression {
 
     var step: Bound { get }
 
+    @_semantics("autodiff.nonvarying")
     func relativeTo<C>(_ collection: C) -> StridedRange<Bound>
         where C : Collection, Self.Bound == C.Index
 }
@@ -77,6 +78,7 @@ public struct PartialStridedRange<Partial>: PartialRangeExpression
     }
     
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public func relativeTo<C>(_ collection: C) -> StridedRange<Bound>
         where C : Collection, Self.Bound == C.Index
     {
@@ -176,6 +178,7 @@ public struct RelativeRange: RangeExpression, PartialRangeExpression {
     public func contains(_ element: Int) -> Bool { true }
     
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public func relativeTo<C>(_ collection: C) -> StridedRange<Bound>
         where C : Collection, Self.Bound == C.Index
     {
@@ -232,6 +235,7 @@ public struct StridedRange<Bound>: StridedRangeExpression, Collection
     }
     
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public func relativeTo<C>(_ collection: C) -> Self
         where C : Collection, Bound == C.Index { self }
     
@@ -257,11 +261,13 @@ extension Range: StridedRangeExpression, PartialRangeExpression
     where Bound: RangeBound
 {
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public var stridedRange: StridedRange<Bound> {
         StridedRange(from: lowerBound, to: upperBound, by: step)
     }
 
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public func relativeTo<C>(_ collection: C) -> StridedRange<Bound>
         where C : Collection, Self.Bound == C.Index
     {
@@ -281,11 +287,13 @@ extension ClosedRange: StridedRangeExpression, PartialRangeExpression
     where Bound: RangeBound
 {
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public var stridedRange: StridedRange<Bound> {
         StridedRange(from: lowerBound, through: upperBound, by: step)
     }
     
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public func relativeTo<C>(_ collection: C) -> StridedRange<Bound>
         where C : Collection, Self.Bound == C.Index
     {
@@ -303,6 +311,7 @@ extension ClosedRange: StridedRangeExpression, PartialRangeExpression
 
 extension PartialRangeFrom: PartialRangeExpression where Bound: RangeBound {
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public func relativeTo<C>(_ collection: C) -> StridedRange<Bound>
         where C : Collection, Self.Bound == C.Index
     {
@@ -321,6 +330,7 @@ extension PartialRangeFrom: PartialRangeExpression where Bound: RangeBound {
 
 extension PartialRangeUpTo: PartialRangeExpression where Bound: RangeBound {
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public func relativeTo<C>(_ collection: C) -> StridedRange<Bound>
         where C : Collection, Self.Bound == C.Index
     {
@@ -341,6 +351,7 @@ extension PartialRangeThrough: PartialRangeExpression
     where Bound: RangeBound
 {
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public func relativeTo<C>(_ collection: C) -> StridedRange<Bound>
         where C : Collection, Self.Bound == C.Index
     {
@@ -361,6 +372,7 @@ extension Int: PartialRangeExpression {
     public typealias Bound = Int
     
     @inlinable
+    @_semantics("autodiff.nonvarying")
     public func relativeTo<C>(_ collection: C) -> StridedRange<Bound>
         where C : Collection, Self.Bound == C.Index
     {

--- a/Sources/SwiftRT/tensor/TensorIndexing.swift
+++ b/Sources/SwiftRT/tensor/TensorIndexing.swift
@@ -19,7 +19,7 @@ public extension TensorView where Self: VectorView {
     //--------------------------------------------------------------------------
     @inlinable
     // TODO: fix this
-    //    @differentiable(where Self: DifferentiableTensorView)
+    @differentiable(where Self: DifferentiableTensorView)
     subscript(index: Int) -> Element {
         get {
             view(at: makePositive(index: (index)),
@@ -41,11 +41,11 @@ public extension TensorView where Self: VectorView {
         where R: PartialRangeExpression, R.Bound == Int
         {
         get {
-            let r = withoutDerivative(at: range.relativeTo(0..<extents[0]))
+            let r = range.relativeTo(0..<extents[0])
             return self[(r.start), (r.end), (r.step)]
         }
         set {
-            let r = withoutDerivative(at: range.relativeTo(0..<extents[0]))
+            let r = range.relativeTo(0..<extents[0])
             self[(r.start), (r.end), (r.step)] = newValue
         }
     }
@@ -53,7 +53,7 @@ public extension TensorView where Self: VectorView {
 
 public extension TensorView {
     @inlinable
-    //    @differentiable(where Self: DifferentiableTensorView)
+    @differentiable(where Self: DifferentiableTensorView)
     subscript(range: UnboundedRange) -> Self { self }
     
     @inlinable
@@ -61,13 +61,13 @@ public extension TensorView {
     subscript<R>(range: R) -> Self
         where R: PartialRangeExpression, R.Bound == Int {
         get {
-            let (start, end, steps) = withoutDerivative(at:
-                getItemRange(range.relativeTo(0..<extents[0])))
+            let (start, end, steps) =
+                getItemRange(range.relativeTo(0..<extents[0]))
             return self[start, end, steps]
         }
         set {
-            let (start, end, steps) = withoutDerivative(at:
-                getItemRange(range.relativeTo(0..<extents[0])))
+            let (start, end, steps) =
+                getItemRange(range.relativeTo(0..<extents[0]))
             self[start, end, steps] = newValue
         }
     }

--- a/Sources/SwiftRT/tensor/TensorView.swift
+++ b/Sources/SwiftRT/tensor/TensorView.swift
@@ -197,6 +197,7 @@ public extension TensorView where Element: AnyElement {
     /// can get and set the value of a single element tensor.
     /// - Returns: the only element in the tensor
     @inlinable
+    @_semantics("autodiff.nonvarying")
     var element: Element {
         get {
             assert(shape.isScalar, "the `element` property expects " +
@@ -224,6 +225,7 @@ public extension TensorView {
     var count: Int { shape.count }
     /// the extents of the view
     @inlinable
+    @_semantics("autodiff.nonvarying")
     var extents: Shape.Array { shape.extents }
     /// `true` if the values are contiguosly arranged in memory
     @inlinable
@@ -264,6 +266,7 @@ public extension TensorView {
     //--------------------------------------------------------------------------
     /// makePositive(index:
     @inlinable
+    @_semantics("autodiff.nonvarying")
     func makePositive(index: Shape.Tuple) -> Shape.Array {
         var result = Shape.Array(index)
         for i in 0..<result.count {

--- a/Sources/SwiftRT/tensor/Tensors.swift
+++ b/Sources/SwiftRT/tensor/Tensors.swift
@@ -370,7 +370,7 @@ public extension MatrixView {
     // single element
     @inlinable
     // TODO: fix this
-    //    @differentiable(where Self: DifferentiableTensorView)
+    @differentiable(where Self: DifferentiableTensorView)
     subscript(r: Int, c: Int) -> Element {
         get {
             view(at: makePositive(index: (r, c)),
@@ -395,14 +395,14 @@ public extension MatrixView {
         C: PartialRangeExpression, C.Bound == Int
     {
         get {
-            let r = withoutDerivative(at: rows.relativeTo(0..<extents[0]))
-            let c = withoutDerivative(at: cols.relativeTo(0..<extents[1]))
+            let r = rows.relativeTo(0..<extents[0])
+            let c = cols.relativeTo(0..<extents[1])
             return self[(r.start, c.start), (r.end, c.end), (r.step, c.step)]
         }
         
         set {
-            let r = withoutDerivative(at: rows.relativeTo(0..<extents[0]))
-            let c = withoutDerivative(at: cols.relativeTo(0..<extents[1]))
+            let r = rows.relativeTo(0..<extents[0])
+            let c = cols.relativeTo(0..<extents[1])
             self[(r.start, c.start), (r.end, c.end), (r.step, c.step)] = newValue
         }
     }
@@ -634,8 +634,7 @@ public extension VolumeView {
     //--------------------------------------------------------------------------
     // single element
     @inlinable
-    // TODO: fix this
-//    @differentiable(where Self: DifferentiableTensorView)
+    @differentiable(where Self: DifferentiableTensorView)
     subscript(d: Int, r: Int, c: Int) -> Element {
         get { self[(d, r, c), (d + 1, r + 1, c + 1), Shape.ones.tuple].element }
         set {
@@ -653,18 +652,18 @@ public extension VolumeView {
         C: PartialRangeExpression, C.Bound == Int
         {
         get {
-            let d = withoutDerivative(at: deps.relativeTo(0..<extents[0]))
-            let r = withoutDerivative(at: rows.relativeTo(0..<extents[1]))
-            let c = withoutDerivative(at: cols.relativeTo(0..<extents[2]))
+            let d = deps.relativeTo(0..<extents[0])
+            let r = rows.relativeTo(0..<extents[1])
+            let c = cols.relativeTo(0..<extents[2])
             return self[(d.start, r.start, c.start),
                         (d.end, r.end, c.end),
                         (d.step, r.step, c.step)]
         }
         
         set {
-            let d = withoutDerivative(at: deps.relativeTo(0..<extents[0]))
-            let r = withoutDerivative(at: rows.relativeTo(0..<extents[1]))
-            let c = withoutDerivative(at: cols.relativeTo(0..<extents[2]))
+            let d = deps.relativeTo(0..<extents[0])
+            let r = rows.relativeTo(0..<extents[1])
+            let c = cols.relativeTo(0..<extents[2])
             self[(d.start, r.start, c.start),
                  (d.end, r.end, c.end),
                  (d.step, r.step, c.step)] = newValue


### PR DESCRIPTION
Replace `withoutDerivative(at:)` with `@_semantics("autodiff.nonvarying")`.

`@noDerivative` attribute can now be declared on all function-like declarations
to imply non-varying semantics.

Marking declarations as `@noDerivative` is a usability improvement over using
`withoutDerivative(at:)` at use sites. However, `@noDerivative` is invasive
because it requires annotation on original declarations. There may exist a more
elegant solution.

After https://github.com/apple/swift/pull/29647, `@_semantics("autodiff.nonvarying")` usages can be
renamed to `@noDerivative`.