### PR TITLE
[AutoDiff] Workaround for TF-1181.

### DIFF
--- a/Sources/SwiftRT/platform/Platform.swift
+++ b/Sources/SwiftRT/platform/Platform.swift
@@ -37,7 +37,9 @@ public final class Platform {
     @usableFromInline static var bufferIdCounter: Int = 0
 
     // maybe thread local
-    public static var service: PlatformAPI = CpuService()
+    // TODO(TF-1181): Fix crash regarding existential. Use concrete type for now.
+    // public static var service: PlatformAPI = CpuService()
+    public static var service = CpuService()
     
     //--------------------------------------------------------------------------
     /// the Platform log writing object


### PR DESCRIPTION
Workaround crash when differentiating apply with opened existential argument.

---

Verified that `swift test` succeeds.
@marcrasi and I are looking into [TF-1181](https://bugs.swift.org/browse/TF-1181) so we can revert this workaround if desired.