### PR TITLE
Fix `Convolution<T>`.

### DIFF
--- a/Sources/SwiftRT/functions/Convolution.swift
+++ b/Sources/SwiftRT/functions/Convolution.swift
@@ -18,45 +18,47 @@ import Numerics
 
 ////==============================================================================
 ///// Convolution
-//public struct Convolution<T>: Layer where
-//    T: DifferentiableTensorView & ElementaryFunctions,
-//    T.Element: ScalarElement & Real
-//{
-//    /// The convolution filter
-//    public var filter: T
-//    /// The bias vector
-//    public var bias: T
-//    /// The element-wise activation function.
-//    @noDerivative public let activation: ActivationMode
-//    /// The strides of the sliding window for spatial dimensions.
-//    @noDerivative public let strides: T.Bounds
-//    /// The padding algorithm for convolution.
-//    @noDerivative public let padding: Padding
-//    /// The dilation factor for spatial dimensions.
-//    @noDerivative public let dilation: T.Bounds
-//
-//    public init(
-//        for tensor: T,
-//        resultShape: inout Shape<T.Bounds>,
-//        filter: T,
-//        bias: T,
-//        activation: ActivationMode = .identity,
-//        strides: T.Bounds = T.Bounds.one,
-//        padding: Padding = .valid,
-//        dilation: T.Bounds = T.Bounds.one)
-//    {
-//        self.filter = filter
-//        self.bias = bias
-//        self.activation = activation
-//        self.strides = strides
-//        self.padding = padding
-//        self.dilation = dilation
-//    }
-//
-//    public func callAsFunction(_ input: T) -> T {
-//        fatalError()
-//    }
-//}
+public struct Convolution<T>: Layer where
+    T: DifferentiableTensorView,
+    T.Element: ScalarElement & Real
+{
+    /// The convolution filter
+    public var filter: T
+    /// The bias vector
+    public var bias: T
+    /// The element-wise activation function.
+    @noDerivative public let activation: ActivationMode
+    /// The strides of the sliding window for spatial dimensions.
+    @noDerivative public let strides: T.Bounds
+    /// The padding algorithm for convolution.
+    @noDerivative public let padding: Padding
+    /// The dilation factor for spatial dimensions.
+    @noDerivative public let dilation: T.Bounds
+
+    public init(
+        for tensor: T,
+        resultShape: inout Shape<T.Bounds>,
+        filter: T,
+        bias: T,
+        activation: ActivationMode = .identity,
+        strides: T.Bounds = T.Bounds.one,
+        padding: Padding = .valid,
+        dilation: T.Bounds = T.Bounds.one)
+    {
+        self.filter = filter
+        self.bias = bias
+        self.activation = activation
+        self.strides = strides
+        self.padding = padding
+        self.dilation = dilation
+    }
+
+    @differentiable
+    public func callAsFunction(_ input: T) -> T {
+        // TODO: Write actual implementation.
+        input
+    }
+}
 
 //==============================================================================
 // ConvolutionProperties

--- a/Sources/SwiftRT/functions/Layer.swift
+++ b/Sources/SwiftRT/functions/Layer.swift
@@ -14,9 +14,11 @@
 // limitations under the License.
 //
 
-public protocol Module: EuclideanDifferentiable, KeyPathIterable
-    where TangentVector: VectorProtocol & ElementaryFunctions &
-                         PointwiseMultiplicative & KeyPathIterable {
+// Note: `Module` and `Layer` protocol definitions are adapted and simplified from:
+// https://github.com/tensorflow/swift-apis/blob/master/Sources/TensorFlow/Layer.swift
+
+public protocol Module: Differentiable, KeyPathIterable
+    where TangentVector: KeyPathIterable {
     /// The input type of the layer.
     associatedtype Input
     /// The output type of the layer.


### PR DESCRIPTION
Use simplified `Module`/`Layer` protocol definitions.

The protocols from `tensorflow/swift-apis` contain many requirements, which are
not ideal here. Requirements can be added incrementally as functionality becomes
needed.