### PR TITLE
fixes Tensor.element and stack derivatives

### DIFF
--- a/Sources/SwiftRT/numpy/RankFunctions.swift
+++ b/Sources/SwiftRT/numpy/RankFunctions.swift
@@ -484,14 +484,14 @@ import Foundation
 ///
 //==============================================================================
 // Rank1
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: [Tensor1<E>], axis: Int = 0)
     -> Tensor2<E>
 {
     Tensor2<E>(stacking: arrays, axis: axis)
 }
 
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: Tensor1<E>..., axis: Int = 0)
     -> Tensor2<E>
 {
@@ -510,14 +510,14 @@ import Foundation
 
 //==============================================================================
 // Rank2
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: [Tensor2<E>], axis: Int = 0)
     -> Tensor3<E>
 {
     Tensor3<E>(stacking: arrays, axis: axis)
 }
 
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: Tensor2<E>..., axis: Int = 0)
     -> Tensor3<E>
 {
@@ -536,14 +536,14 @@ import Foundation
 
 //==============================================================================
 // Rank3
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: [Tensor3<E>], axis: Int = 0)
     -> Tensor4<E>
 {
     Tensor4<E>(stacking: arrays, axis: axis)
 }
 
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: Tensor3<E>..., axis: Int = 0)
     -> Tensor4<E>
 {
@@ -562,14 +562,14 @@ import Foundation
 
 //==============================================================================
 // Rank4
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: [Tensor4<E>], axis: Int = 0)
     -> Tensor5<E>
 {
     Tensor5<E>(stacking: arrays, axis: axis)
 }
 
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: Tensor4<E>..., axis: Int = 0)
     -> Tensor5<E>
 {
@@ -588,14 +588,14 @@ import Foundation
 
 //==============================================================================
 // Rank5
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: [Tensor5<E>], axis: Int = 0)
     -> Tensor6<E>
 {
     Tensor6<E>(stacking: arrays, axis: axis)
 }
 
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: Tensor5<E>..., axis: Int = 0)
     -> Tensor6<E>
 {

--- a/Sources/SwiftRT/numpy/RankFunctions.swift.gyb
+++ b/Sources/SwiftRT/numpy/RankFunctions.swift.gyb
@@ -110,14 +110,14 @@ numShapes = 6
 %for n in range(1, numShapes):
 //==============================================================================
 // Rank${n}
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: [Tensor${n}<E>], axis: Int = 0)
     -> Tensor${n + 1}<E>
 {
     Tensor${n + 1}<E>(stacking: arrays, axis: axis)
 }
 
-//@differentiable(where E: DifferentiableElement)
+@differentiable(where E: DifferentiableElement)
 @inlinable public func stack<E>(_ arrays: Tensor${n}<E>..., axis: Int = 0)
     -> Tensor${n + 1}<E>
 {

--- a/Sources/SwiftRT/tensor/Tensor.swift
+++ b/Sources/SwiftRT/tensor/Tensor.swift
@@ -440,7 +440,6 @@ public extension Tensor {
 public extension Tensor {
     /// first
     /// - Returns: the first element in the tensor
-    @_semantics("autodiff.nonvarying")
     @inlinable var first: Element {
         storage.element(at: baseOffset)
     }
@@ -448,7 +447,7 @@ public extension Tensor {
     /// element
     /// can get and set the value of a single element tensor.
     /// - Returns: the only element in the tensor
-    @_semantics("autodiff.nonvarying")
+    @differentiable(where Element: DifferentiableElement)
     @inlinable var element: Element {
         get {
             assert(count == 1, "the `element` property expects " +
@@ -460,6 +459,18 @@ public extension Tensor {
                 "the tensor to have a single Element")
             storage.setElement(value: newValue, at: baseOffset)
         }
+    }
+
+    @derivative(of: element)
+    @inlinable func vjpElement() -> (
+      value: Element,
+      pullback: (Element) -> Self
+    ) where Element: DifferentiableElement {
+      (element, { v in
+        var result = zeros(like: self)
+        result.element = v
+        return result
+      })
     }
 }
 

--- a/Tests/SwiftRTTests/test_Shape.swift
+++ b/Tests/SwiftRTTests/test_Shape.swift
@@ -160,16 +160,15 @@ class test_Shape: XCTestCase {
     //--------------------------------------------------------------------------
     // test_stackingGradients
     func test_stackingGradients() {
-//        let a1 = array([1, 2, 3, 4, 5])
-//        let b1 = array([6, 7, 8, 9, 10])
-//        let a2 = array([1, 1, 1, 1, 1])
-//        let b2 = array([1, 1, 1, 1, 1])
-//        let grads = gradient(at: a2, b2) { a, b in
-//            stack(a1 * a, b1 * b, axis: -1).sum().element
-//        }
-        // TODO: this fails due to an AD bug
-//        XCTAssertEqual(a1, grads.0)
-//        XCTAssertEqual(b1, grads.1)
+        let a1 = array([1, 2, 3, 4, 5])
+        let b1 = array([6, 7, 8, 9, 10])
+        let a2 = array([1, 1, 1, 1, 1])
+        let b2 = array([1, 1, 1, 1, 1])
+        let grads = gradient(at: a2, b2) { a, b in
+            stack(a1 * a, b1 * b, axis: -1).sum().element
+        }
+        XCTAssertEqual(a1, grads.0)
+        XCTAssertEqual(b1, grads.1)
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
* Removes `@_semantics("autodiff.nonvarying")` from `Tensor.element`, and makes it `@differentiable` instead. (`@_semantics("autodiff.nonvarying")` tells AD that the derivative is zero, which is why the test was getting zero derivatives.)
* Fixes a bug in `vjpStack` where it was returning a zero derivative. See the comments in there for more information.
* Uncomments some `@differentiable` attributes so that `stack` is differentiable.