### PR TITLE
Avoid unnecessary tensor materialization in tensor-element op derivatives.

### DIFF
--- a/Sources/SwiftRTCore/operators/AlgebraicField.swift
+++ b/Sources/SwiftRTCore/operators/AlgebraicField.swift
@@ -41,7 +41,6 @@ import Numerics
 -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) ->(Tensor<S,E>, Tensor<S,E>))
 where S: TensorShape, E: DifferentiableElement
 {
-    print("calling _vjpAdd both")
     return (lhs + rhs, { v in (v, v) })
 }
 
@@ -50,11 +49,7 @@ where S: TensorShape, E: DifferentiableElement
 -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) ->(Tensor<S,E>))
 where S: TensorShape, E: DifferentiableElement
 {
-    print("calling _vjpAdd wrt lhs")
-    return (lhs, {
-        print("calling _vjpAdd pullback wrt lhs")
-        return $0
-    })
+    return (lhs, { $0 })
 }
 
 
@@ -63,7 +58,6 @@ where S: TensorShape, E: DifferentiableElement
 @inlinable public func add<S,E>(_ lhs: Tensor<S,E>, _ rhs: E) -> Tensor<S,E>
     where S: TensorShape, E: AdditiveArithmetic
 {
-    print("calling add lhs + scalar")
     return add(lhs, repeating(rhs, like: lhs))
 }
 
@@ -72,11 +66,7 @@ where S: TensorShape, E: DifferentiableElement
 -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) ->(Tensor<S,E>))
 where S: TensorShape, E: DifferentiableElement
 {
-    print("calling _vjpAdd wrt lhs")
-    return (lhs, {
-        print("calling _vjpAdd pullback wrt lhs")
-        return $0
-    })
+    return (lhs, { $0 })
 }
 
 //------------------------------------------------------------------------------
@@ -92,11 +82,7 @@ where S: TensorShape, E: DifferentiableElement
 -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) ->(Tensor<S,E>))
 where S: TensorShape, E: DifferentiableElement
 {
-    print("calling _vjpAdd wrt rhs")
-    return (rhs, {
-        print("calling _vjpAdd pullback wrt rhs")
-        return $0
-    })
+    return (rhs, { $0 })
 }
 
 //------------------------------------------------------------------------------

--- a/Sources/SwiftRTCore/operators/AlgebraicField.swift
+++ b/Sources/SwiftRTCore/operators/AlgebraicField.swift
@@ -49,7 +49,7 @@ where S: TensorShape, E: DifferentiableElement
 -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) ->(Tensor<S,E>))
 where S: TensorShape, E: DifferentiableElement
 {
-    return (lhs, { $0 })
+    return (lhs + rhs, { $0 })
 }
 
 
@@ -66,7 +66,7 @@ where S: TensorShape, E: DifferentiableElement
 -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) ->(Tensor<S,E>))
 where S: TensorShape, E: DifferentiableElement
 {
-    return (lhs, { $0 })
+    return (lhs + rhs, { $0 })
 }
 
 //------------------------------------------------------------------------------
@@ -82,7 +82,7 @@ where S: TensorShape, E: DifferentiableElement
 -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) ->(Tensor<S,E>))
 where S: TensorShape, E: DifferentiableElement
 {
-    return (rhs, { $0 })
+    return (lhs + rhs, { $0 })
 }
 
 //------------------------------------------------------------------------------

--- a/Sources/SwiftRTCore/operators/AlgebraicField.swift
+++ b/Sources/SwiftRTCore/operators/AlgebraicField.swift
@@ -92,7 +92,7 @@ where S: TensorShape, E: DifferentiableElement
 -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) ->(Tensor<S,E>))
 where S: TensorShape, E: DifferentiableElement
 {
-    print("calling _vjpAdd wrt lhs")
+    print("calling _vjpAdd wrt rhs")
     return (rhs, {
         print("calling _vjpAdd pullback wrt rhs")
         return $0
@@ -107,6 +107,7 @@ public extension Tensor where Element: AdditiveArithmetic {
     }
 
     @differentiable(where Element: DifferentiableElement)
+    @differentiable(wrt: lhs where Element: DifferentiableElement)
     @inlinable static func +(lhs: Self, rhs: Element) -> Self {
         add(lhs, rhs)
     }
@@ -117,6 +118,7 @@ public extension Tensor where Element: AdditiveArithmetic {
     }
 
     @differentiable(where Element: DifferentiableElement)
+    @differentiable(wrt: rhs where Element: DifferentiableElement)
     @inlinable static func +(lhs: Element, rhs: Self) -> Self {
         add(lhs, rhs)
     }


### PR DESCRIPTION
Add derivatives for `(Tensor, Element) -> Tensor` operations differentiable with
respect to only the `Tensor` argument, to avoid unnecessary tensor
materialization in pullbacks.

Done for tensor-element operations: `+`, `-`, `*`, `/`.

Delete unnecessary top-level tensor-element op functions. These entry points
perform only forwarding and are unnecessary.