### PR TITLE
Fix `Complex: DifferentiableElement` conformance.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/apple/swift-numerics",
         "state": {
           "branch": "master",
-          "revision": "119377cc49247839e03a7d3d1488f6b711b5e917",
+          "revision": "c634b5ddcea8445244b7cde1e5deddb8adf58e37",
           "version": null
         }
       }

--- a/Sources/SwiftRTCore/tensor/Tensor.swift
+++ b/Sources/SwiftRTCore/tensor/Tensor.swift
@@ -176,11 +176,8 @@ public protocol DifferentiableElement:
 extension Float: DifferentiableElement {}
 extension Double: DifferentiableElement {}
 
-// this is defined with the typealias because of AD same file
-// compiler requirements. Hopefully fixed in the future
-extension Complex: DifferentiableElement {
-  public typealias TangentVector = Self
-}
+extension Complex: DifferentiableElement
+where RealType: Differentiable, RealType.TangentVector == RealType {}
 
 // Differentiable conformance
 extension Tensor: Differentiable & DifferentiableTensor


### PR DESCRIPTION
The `Complex: Differentiable` conformance has changed in apple/swift-numerics.

`Complex` conditionally conforms to `Differentiable` where `RealType: Differentiable, RealType.TangentVector == RealType`.

The `Complex: DifferentiableElement` conformance must be adapted accordingly.