### PR TITLE
[AutoDiff] Add VJPs for atan2 and erf.

### DIFF
--- a/Sources/SwiftRTCore/operators/Math.swift
+++ b/Sources/SwiftRTCore/operators/Math.swift
@@ -194,8 +194,11 @@ where E.Value: DifferentiableNumeric & Real {
     x: Tensor<S,E>
 ) -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) -> (Tensor<S,E>, Tensor<S,E>))
 where E.Value: DifferentiableNumeric & Real {
-    // Dan
-    fatalError("Not implemented")
+    let value = atan2(y: y, x: x)
+    return (value, { v in
+        let gradInv = v / ((x * x) + (y * y))
+        return (x * gradInv, -y * gradInv)
+    })
 }
 
 //==============================================================================
@@ -282,8 +285,10 @@ where E.Value: DifferentiableNumeric & Real {
 ) -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) -> Tensor<S,E>)
     where E.Value: DifferentiableNumeric & Real
 {
-    // Dan
-    fatalError("Not implemented")
+    let value = erf(x)
+    return (value, { v in
+        return v * (2 / E.Value.pi.squareRoot()) * exp(-(x * x))
+    })
 }
 
 //==============================================================================

--- a/Tests/SwiftRTCoreTests/test_Math.swift
+++ b/Tests/SwiftRTCoreTests/test_Math.swift
@@ -22,6 +22,8 @@ class test_Math: XCTestCase {
     // support terminal test run
     static var allTests = [
         ("test_abs", test_abs),
+        ("test_atan2", test_atan2),
+        ("test_erf", test_erf),
         ("test_exp", test_exp),
         ("test_log", test_log),
         ("test_neg", test_neg),
@@ -54,6 +56,29 @@ class test_Math: XCTestCase {
 
         let g = pullback(at: b, in: { abs($0) })(ones(like: b))
         XCTAssert(g == [-1, 1, -1, 1, -1])
+    }
+
+    //--------------------------------------------------------------------------
+    // test_atan2
+    func test_atan2() {
+        let a = array([[1, 2], [3, 4], [5, 6]])
+        let b = array([[1, -2], [-3, 4], [5, -6]])
+        let result = atan2(y: a, x: b)
+        XCTAssert(result == [[0.7853982, 2.3561945], [2.3561945, 0.7853982], [0.7853982, 2.3561945]])
+
+        let (da, db) = pullback(at: a, b, in: { atan2(y: $0, x: $1) })(ones(like: result))
+        XCTAssert(da == [[0.5, -0.25], [-0.16666667, 0.125], [0.099999994, -0.083333336]])
+        XCTAssert(db == [[-0.5, -0.25], [-0.16666667, -0.125], [-0.099999994, -0.083333336]])
+    }
+
+    //--------------------------------------------------------------------------
+    // test_erf
+    func test_erf() {
+        let a = array([[0, -1], [2, -3], [4, 5]])
+        XCTAssert(erf(a) == [[0.0, -0.8427008], [0.9953223, -0.9999779], [1.0, 1.0]])
+
+        let da = pullback(at: a, in: { erf($0) })(ones(like: a))
+        XCTAssert(da == [[1.1283792, 0.41510752], [0.020666987, 0.00013925305], [1.2698236e-07, 1.5670867e-11]])
     }
     
     //--------------------------------------------------------------------------


### PR DESCRIPTION
`atan2` VJP reference implementation:

<details>

```python
import tensorflow as tf

x = tf.constant([[1, 2], [3, 4], [5, 6]], dtype=tf.float32)
y = tf.constant([[1, -2], [-3, 4], [5, -6]], dtype=tf.float32)

with tf.GradientTape(persistent=True) as tape:
    tape.watch([x, y])
    result = tf.atan2(x, y)

print("Result")
print(result)
# tf.Tensor(
# [[0.7853982 2.3561945]
#  [2.3561945 0.7853982]
#  [0.7853982 2.3561945]], shape=(3, 2), dtype=float32)

print("Gradient (dx)")
dx = tape.gradient(result, x)
print(dx)
# tf.Tensor(
# [[ 0.5        -0.25      ]
#  [-0.16666667  0.125     ]
#  [ 0.09999999 -0.08333334]], shape=(3, 2), dtype=float32)

print("Gradient (dy)")
dy = tape.gradient(result, y)
print(dy)
# tf.Tensor(
# [[-0.5        -0.25      ]
#  [-0.16666667 -0.125     ]
#  [-0.09999999 -0.08333334]], shape=(3, 2), dtype=float32)
```

</details>

`erf` VJP reference implementation:

<details>

```python
import tensorflow as tf

x = tf.constant([[0, -1], [2, -3], [4, 5]], dtype=tf.float32)

with tf.GradientTape(persistent=True) as tape:
    tape.watch(x)
    result = tf.math.erf(x)

print('Result')
print(result)
# tf.Tensor(
# [[0.7853982 2.3561945]
#  [2.3561945 0.7853982]
#  [0.7853982 2.3561945]], shape=(3, 2), dtype=float32)

print('Gradient (dx)')
dx = tape.gradient(result, x)
print(dx)
# tf.Tensor(
# [[ 0.5        -0.25      ]
#  [-0.16666667  0.125     ]
#  [ 0.09999999 -0.08333334]], shape=(3, 2), dtype=float32)
```

</details>