### PR TITLE
[AutoDiff] Add tensor-scalar max/min VJPs.

### DIFF
--- a/Sources/SwiftRTCore/operators/Comparative.swift
+++ b/Sources/SwiftRTCore/operators/Comparative.swift
@@ -97,8 +97,13 @@ public extension Tensor where TensorElement.Value == Bool {
     _ rhs: E.Value
 ) -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) -> (Tensor<S,E>, E.Value)
 ) where S: TensorShape, E.Value: Comparable & DifferentiableNumeric {
-    // Dan
-    fatalError()
+    let value = min(lhs, rhs)
+    return (value, { v in
+        var resultTrue = Tensor(like: lhs)
+        var resultFalse = Tensor(like: lhs)
+        Context.currentQueue.vjpMin(lhs, rhs, v, &resultTrue, &resultFalse)
+        return (resultTrue, resultFalse.sum().element)
+    })
 }
 
 @derivative(of: min, wrt: lhs)
@@ -107,8 +112,13 @@ public extension Tensor where TensorElement.Value == Bool {
     _ rhs: E.Value
 ) -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) -> Tensor<S,E>)
 where S: TensorShape, E.Value: Comparable & Numeric & DifferentiableNumeric {
-    // Dan
-    fatalError()
+    let value = max(lhs, rhs)
+    return (value, { v in
+        var resultTrue = Tensor(like: lhs)
+        var resultFalse = Tensor(like: lhs)
+        Context.currentQueue.vjpMin(lhs, rhs, v, &resultTrue, &resultFalse)
+        return resultTrue
+    })
 }
 
 //--------------------------------
@@ -199,8 +209,13 @@ where S: TensorShape, E.Value: DifferentiableNumeric & Comparable {
     _ rhs: E.Value
 ) -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) -> (Tensor<S,E>, E.Value))
 where S: TensorShape, E.Value: Comparable & Numeric & DifferentiableNumeric {
-    // Dan
-    fatalError()
+    let value = max(lhs, rhs)
+    return (value, { v in
+        var resultTrue = Tensor(like: lhs)
+        var resultFalse = Tensor(like: lhs)
+        Context.currentQueue.vjpMax(lhs, rhs, v, &resultTrue, &resultFalse)
+        return (resultTrue, resultFalse.sum().element)
+    })
 }
 
 @derivative(of: max, wrt: lhs)
@@ -209,8 +224,13 @@ where S: TensorShape, E.Value: Comparable & Numeric & DifferentiableNumeric {
     _ rhs: E.Value
 ) -> (value: Tensor<S,E>, pullback: (Tensor<S,E>) -> Tensor<S,E>)
 where S: TensorShape, E.Value: Comparable & Numeric & DifferentiableNumeric {
-    // Dan
-    fatalError()
+    let value = max(lhs, rhs)
+    return (value, { v in
+        var resultTrue = Tensor(like: lhs)
+        var resultFalse = Tensor(like: lhs)
+        Context.currentQueue.vjpMax(lhs, rhs, v, &resultTrue, &resultFalse)
+        return resultTrue
+    })
 }
 
 //--------------------------------

--- a/Sources/SwiftRTCore/platform/cpu/functions/CpuMath.swift
+++ b/Sources/SwiftRTCore/platform/cpu/functions/CpuMath.swift
@@ -664,6 +664,19 @@ extension DeviceQueue {
               "vjpMin(x: \(x.name), y: \(y.name), scale: \(scale.name))")
             { $0 <= $1 ? $2 : E.Value.zero }
     }
+
+    /// cpu_vjpMin
+    @inlinable func cpu_vjpMin<S,E>(
+        _ x: Tensor<S,E>,
+        _ y: E.Value,
+        _ scale: Tensor<S,E>,
+        _ out: inout Tensor<S,E>)
+    where E.Value: Comparable & Numeric {
+        mapOp(x, scale, y, &out,
+              "vjpMin(x: \(x.name), y: \(y), scale: \(scale.name))")
+            { $0 <= $2 ? $1 : E.Value.zero }
+    }
+
     /// cpu_vjpMin
     @inlinable func cpu_vjpMin<S,E>(
         _ x: Tensor<S,E>,
@@ -676,7 +689,21 @@ extension DeviceQueue {
               "vjpMin(x: \(x.name), y: \(y.name), scale: \(scale.name))")
             { $0 <= $1 ? ($2, E.Value.zero) : (E.Value.zero, $2) }
     }
-    
+
+    /// cpu_vjpMin
+    @inlinable func cpu_vjpMin<S,E>(
+        _ x: Tensor<S,E>,
+        _ y: E.Value,
+        _ scale: Tensor<S,E>,
+        _ resultTrue: inout Tensor<S,E>,
+        _ resultFalse: inout Tensor<S,E>
+    ) where E.Value: Comparable & Numeric {
+        mapOp(x, scale, y, &resultTrue, &resultFalse,
+              "vjpMin(x: \(x.name), y: \(y), scale: \(scale.name))") {
+            $0 <= $2 ? ($1, E.Value.zero) : (E.Value.zero, $1)
+        }
+    }
+
     //--------------------------------------------------------------------------
     /// cpu_vjpMax
     @inlinable func cpu_vjpMax<S,E>(
@@ -689,6 +716,19 @@ extension DeviceQueue {
               "vjpMax(x: \(x.name), y: \(y.name), scale: \(scale.name))")
             { $0 >= $1 ? $2 : E.Value.zero }
     }
+
+    /// cpu_vjpMax
+    @inlinable func cpu_vjpMax<S,E>(
+        _ x: Tensor<S,E>,
+        _ y: E.Value,
+        _ scale: Tensor<S,E>,
+        _ out: inout Tensor<S,E>)
+    where E.Value: Comparable & Numeric {
+        mapOp(x, scale, y, &out,
+              "vjpMax(x: \(x.name), y: \(y), scale: \(scale.name))")
+            { $0 >= $2 ? $1 : E.Value.zero }
+    }
+
     /// cpu_vjpMax
     @inlinable func cpu_vjpMax<S,E>(
         _ x: Tensor<S,E>,
@@ -700,6 +740,20 @@ extension DeviceQueue {
         mapOp(x, y, scale, &resultTrue, &resultFalse,
               "vjpMax(x: \(x.name), y: \(y.name), scale: \(scale.name))") {
             $0 >= $1 ? ($2, E.Value.zero) : (E.Value.zero, $2)
+        }
+    }
+
+    /// cpu_vjpMax
+    @inlinable func cpu_vjpMax<S,E>(
+        _ x: Tensor<S,E>,
+        _ y: E.Value,
+        _ scale: Tensor<S,E>,
+        _ resultTrue: inout Tensor<S,E>,
+        _ resultFalse: inout Tensor<S,E>
+    ) where E.Value: Comparable & Numeric {
+        mapOp(x, scale, y, &resultTrue, &resultFalse,
+              "vjpMax(x: \(x.name), y: \(y), scale: \(scale.name))") {
+            $0 >= $2 ? ($1, E.Value.zero) : (E.Value.zero, $1)
         }
     }
 }
@@ -1091,22 +1145,46 @@ extension DeviceQueue where Self: CpuFunctions
         _ out: inout Tensor<S,E>)
     where E.Value: Comparable & Numeric
     { cpu_vjpMin(x, y, scale, &out) }
-    
+
+    @inlinable func vjpMin<S,E>(
+        _ x: Tensor<S,E>, _ y: E.Value, _ scale: Tensor<S,E>,
+        _ out: inout Tensor<S,E>)
+    where E.Value: Comparable & Numeric
+    { cpu_vjpMin(x, y, scale, &out) }
+
     @inlinable func vjpMin<S,E>(
         _ x: Tensor<S,E>, _ y: Tensor<S,E>, _ scale: Tensor<S,E>,
         _ resultTrue: inout Tensor<S,E>, _ resultFalse: inout Tensor<S,E>)
     where E.Value: Comparable & Numeric
     { cpu_vjpMin(x, y, scale, &resultTrue, &resultFalse) }
-    
+
+    @inlinable func vjpMin<S,E>(
+        _ x: Tensor<S,E>, _ y: E.Value, _ scale: Tensor<S,E>,
+        _ resultTrue: inout Tensor<S,E>, _ resultFalse: inout Tensor<S,E>)
+    where E.Value: Comparable & Numeric
+    { cpu_vjpMin(x, y, scale, &resultTrue, &resultFalse) }
+
     //--------------------------------------------------------------------------
     @inlinable func vjpMax<S,E>(
         _ x: Tensor<S,E>, _ y: Tensor<S,E>, _ scale: Tensor<S,E>,
         _ out: inout Tensor<S,E>)
     where E.Value: Comparable & Numeric
     { cpu_vjpMax(x, y, scale, &out) }
-    
+
+    @inlinable func vjpMax<S,E>(
+        _ x: Tensor<S,E>, _ y: E.Value, _ scale: Tensor<S,E>,
+        _ out: inout Tensor<S,E>)
+    where E.Value: Comparable & Numeric
+    { cpu_vjpMax(x, y, scale, &out) }
+
     @inlinable func vjpMax<S,E>(
         _ x: Tensor<S,E>, _ y: Tensor<S,E>, _ scale: Tensor<S,E>,
+        _ resultTrue: inout Tensor<S,E>, _ resultFalse: inout Tensor<S,E>)
+    where E.Value: Comparable & Numeric
+    { cpu_vjpMax(x, y, scale, &resultTrue, &resultFalse) }
+
+    @inlinable func vjpMax<S,E>(
+        _ x: Tensor<S,E>, _ y: E.Value, _ scale: Tensor<S,E>,
         _ resultTrue: inout Tensor<S,E>, _ resultFalse: inout Tensor<S,E>)
     where E.Value: Comparable & Numeric
     { cpu_vjpMax(x, y, scale, &resultTrue, &resultFalse) }


### PR DESCRIPTION
Add `DeviceQueue.mapOp` overload with type `(tensor, tensor, scalar) -> (out, out)`.

Add tensor-scalar `DeviceQueue.cpu_vjp{Max,Min}` overloads in addition to
existing tensor-tensor versions.

`swift test --filter test_Comparative` now passes.

---

`min`/`max` gradient Python reference implementation:

<details>

```python
import tensorflow as tf

a = tf.constant([[0, 1], [-2, -3], [-4, 5]], dtype=tf.float32)
b = tf.constant([[0, -1], [-2, 3], [-4, 5]], dtype=tf.float32)


def test_grad(op, tensor, scalar):
    with tf.GradientTape(persistent=True) as tape:
        tape.watch(tensor)
        result = op(tensor, scalar)
    print("Result")
    print(result)
    print()
    print("Gradient")
    print(tape.gradient(result, tensor))


test_grad(tf.math.maximum, a, -2)
# Result
# tf.Tensor(
# [[ 0.  1.]
#  [-2. -2.]
#  [-2.  5.]], shape=(3, 2), dtype=float32)
#
# Gradient
# tf.Tensor(
# [[1. 1.]
#  [1. 0.]
#  [0. 1.]], shape=(3, 2), dtype=float32)

test_grad(tf.math.minimum, a, -2)
# Result
# tf.Tensor(
# [[-2. -2.]
#  [-2. -3.]
#  [-4. -2.]], shape=(3, 2), dtype=float32)
#
# Gradient
# tf.Tensor(
# [[0. 0.]
#  [1. 1.]
#  [1. 0.]], shape=(3, 2), dtype=float32)
```