### PR TITLE
build: modernise and support CMake properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.18)
 project(swiftrt
   LANGUAGES Swift)
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,138 +1,82 @@
-cmake_minimum_required(VERSION 3.5)
-project(swiftrt)
+cmake_minimum_required(VERSION 3.17)
+project(swiftrt
+  LANGUAGES Swift)
+include(CTest)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+option(SWIFTRT_ENABLE_CUDA "Enable CUDA Support" NO)
 
-#####################
-# output directories
-string(TOLOWER "${CMAKE_BUILD_TYPE}" SWIFT_BUILD_TYPE)
-set(TARGET_DIR ${PROJECT_SOURCE_DIR}/.build/${SWIFT_BUILD_TYPE})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
-#####################
-# C module map directory for Swift import
-set(MODULES_DIR ${PROJECT_SOURCE_DIR}/Modules)
-
-file(GLOB_RECURSE MODULES_HEADERS
-        ${MODULES_DIR}/*.h
-        ${MODULES_DIR}/*.modulemap)
-
-#####################
-# Cuda
-if ($ENV{SWIFTRT_PLATFORM} MATCHES "cuda")
-        cmake_policy(SET CMP0074 NEW)
-        find_package(CUDA REQUIRED)
-
-        #####################
-        # SwiftRTCuda static library
-        set(SWIFTRT_CUDA_LIB_NAME SwiftRTCuda)
-        set(SWIFTRT_CUDA_DIR ${MODULES_DIR}/${SWIFTRT_CUDA_LIB_NAME})
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
-                -allow-unsupported-compiler
-                --std c++17
-                --expt-relaxed-constexpr
-                -Wno-deprecated-gpu-targets
-                -gencode arch=compute_75,code=sm_75
-                --compiler-options -fPIC)
-
-        if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -DDEBUG -g -G)
-        else()
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -O3 -Xptxas -O3)
-        endif()
-
-        file(GLOB_RECURSE SWIFTRT_CUDA_SOURCES
-                ${SWIFTRT_CUDA_DIR}/*.cu
-                ${SWIFTRT_CUDA_DIR}/*.c
-                ${SWIFTRT_CUDA_DIR}/*.cpp
-                ${SWIFTRT_CUDA_DIR}/*.h
-                ${SWIFTRT_CUDA_DIR}/*.cuh)
-
-        cuda_add_library(${SWIFTRT_CUDA_LIB_NAME} ${SWIFTRT_CUDA_SOURCES})
+if(SWIFTRT_ENABLE_CUDA)
+  enable_language(CUDA)
+  add_subdirectory(Modules/SwiftRTCuda)
 endif()
 
-#####################
-# swift
-#   set SWIFT_HOME in /etc/environment for CLion to pick up
-# then re-login to make visible after setting
-IF(DEFINED ENV{SWIFT_HOME})
-    set(SWIFT_HOME $ENV{SWIFT_HOME})
-ELSE()
-    set(SWIFT_HOME /usr/local/swift)
-ENDIF()
-message("Swift toolchain location: " ${SWIFT_HOME})
+# External Projects
+include(ExternalProject)
 
-set(SWIFT ${SWIFT_HOME}/usr/bin/swift)
-set(SWIFTC ${SWIFT_HOME}/usr/bin/swiftc)
-# set(SWIFT_CLANG_INCLUDE ${SWIFT_HOME}/usr/lib/swift/clang/include)
-#        -Xswiftc -I${SWIFT_CLANG_INCLUDE}
+function(import_module module_name build_dir build_target)
+  add_library(${module_name} IMPORTED UNKNOWN)
+  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set_target_properties(${module_name} PROPERTIES
+      IMPORTED_IMPLIB ${build_dir}/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}${module_name}${CMAKE_IMPORT_LIBRARY_SUFFIX}
+      INTERFACE_INCLUDE_DIRECTORIES ${build_dir}/swift)
+  else()
+    set_target_properties(${module_name} PROPERTIES
+      IMPORTED_LOCATION ${build_dir}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}${module_name}${CMAKE_SHARED_LIBRARY_SUFFIX}
+      INTERFACE_INCLUDE_DIRECTORIES ${build_dir}/swift)
+  endif()
+  add_dependencies(${module_name} ${build_target})
+endfunction()
 
-# configuration specific swift flags
-set(SWIFT_CONFIG_FLAGS
-        # -Xswiftc -warnings-as-errors
-        # -Xswiftc -j12
-        -Xswiftc -I/usr/local/include
-        -Xswiftc -L/usr/local/lib
-        -Xswiftc -L${CMAKE_BINARY_DIR}
-        )
+## swift-numerics
+ExternalProject_Add(swift-numerics
+  GIT_REPOSITORY
+    git://github.com/apple/swift-numerics
+  GIT_TAG
+    master
+  CMAKE_ARGS
+    -D BUILD_SHARED_LIBS=YES
+    -D BUILD_TESTING=NO
+    -D CMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+    -D CMAKE_Swift_COMPILER=${CMAKE_Swift_COMPILER}
+    -D CMAKE_Swift_COMPILER_TARGET=${CMAKE_Swift_COMPILER_TARGET}
+    -D CMAKE_Swift_FLAGS=${CMAKE_Swift_FLAGS}
+  INSTALL_COMMAND
+    ""
+  BUILD_BYPRODUCTS
+    <BINARY_DIR>/lib/${CMAKE_SHARED_LIBRARY_PREFIX}Numerics${CMAKE_SHARED_LIBRARY_SUFFIX}
+    <BINARY_DIR>/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}Numerics${CMAKE_IMPORT_LIBRARY_SUFFIX}
+  UPDATE_DISCONNECTED
+    TRUE
+  STEP_TARGETS
+    build)
+ExternalProject_Get_Property(swift-numerics BINARY_DIR)
+ExternalProject_Get_Property(swift-numerics SOURCE_DIR)
 
-if ($ENV{SWIFTRT_PLATFORM} MATCHES "cuda")
-        set(SWIFT_CONFIG_FLAGS ${SWIFT_CONFIG_FLAGS}
-                -Xswiftc -I${MODULES_DIR}
-                -Xswiftc -I${SWIFTRT_CUDA_DIR}
-                -Xlinker -l${SWIFTRT_CUDA_LIB_NAME}
-                -Xswiftc -I${CUDA_INCLUDE_DIRS}
-                -Xlinker -L${CUDA_TOOLKIT_ROOT_DIR}/lib64
-                )
-endif()
+file(MAKE_DIRECTORY ${BINARY_DIR}/swift)
+file(MAKE_DIRECTORY ${SOURCE_DIR}/Sources/_NumericsShims/include)
 
-# for maximum performance only after thorough testing
-#if (${CMAKE_BUILD_TYPE} MATCHES "Release")
-#        message("Release configuration: -enforce-exclusivity=unchecked -Ounchecked")
-#        set(SWIFT_CONFIG_FLAGS ${SWIFT_CONFIG_FLAGS} -Xswiftc -enforce-exclusivity=unchecked -Xswiftc -Ounchecked)
-#endif()
- 
-# thread sanitizer
-#set(SWIFT_CONFIG_FLAGS ${SWIFT_CONFIG_FLAGS} -Xswiftc -sanitize=thread -Xswiftc -g)
+import_module(Numerics ${BINARY_DIR} swift-numerics-build)
+import_module(ComplexModule ${BINARY_DIR} swift-numerics-build)
+import_module(RealModule ${BINARY_DIR} swift-numerics-build)
 
-# address sanitizer
-#set(SWIFT_CONFIG_FLAGS ${SWIFT_CONFIG_FLAGS} -Xswiftc -sanitize=address -Xswiftc -g)
+add_library(_NumericsShims IMPORTED INTERFACE)
+set_target_properties(_NumericsShims PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${SOURCE_DIR}/Sources/_NumericsShims/include)
+add_dependencies(_NumericsShims swift-numerics-build)
 
-# memory sanitizer
-#set(SWIFT_CONFIG_FLAGS ${SWIFT_CONFIG_FLAGS} -Xswiftc -sanitize=memory -Xswiftc -g)
+set_target_properties(Numerics PROPERTIES
+  INTERFACE_LINK_DIRECTORIES ${BINARY_DIR}/lib
+  INTERFACE_LINK_LIBRARIES _NumericsShims)
 
-#####################
-# SwiftRT module
-set(SWIFTRT_NAME SwiftRT)
-file(GLOB_RECURSE SWIFTRT_SOURCES  ${PROJECT_SOURCE_DIR}/Sources/*.swift)
+find_package(dispatch CONFIG QUIET)
+find_package(Foundation CONFIG QUIET)
 
-set(SWIFTRT_FLAGS ${SWIFT_CONFIG_FLAGS})
-
-add_custom_target(${SWIFTRT_NAME}
-        COMMAND ${SWIFT} build -c ${SWIFT_BUILD_TYPE} ${SWIFTRT_FLAGS}
-        SOURCES ${SWIFTRT_SOURCES} ${MODULES_HEADERS})
-
-if ($ENV{SWIFTRT_PLATFORM} MATCHES "cuda")
-        add_dependencies(${SWIFTRT_NAME} ${SWIFTRT_CUDA_LIB_NAME})
-endif()
-
-#####################
-# SwiftRTTests app
-set(SWIFTRT_TESTS_NAME SwiftRTTests)
-file(GLOB_RECURSE SWIFTRT_TEST_SOURCES
-        ${PROJECT_SOURCE_DIR}/Tests/${SWIFTRT_TESTS_NAME}/*.swift)
-
-#set(TEST_CASE -s ${SWIFTRT_TESTS_NAME}.TestSetup/test_mnistForward)
-
-add_custom_target(${SWIFTRT_TESTS_NAME}
-        COMMAND ${SWIFT} build -c ${SWIFT_BUILD_TYPE} ${SWIFTRT_FLAGS} --build-tests 
-        SOURCES ${SWIFTRT_TEST_SOURCES} ${MODULES_HEADERS})
-
-add_dependencies(${SWIFTRT_TESTS_NAME} ${SWIFTRT_NAME} ${SWIFTRT_CUDA_LIB_NAME})
-
-# whenever the custom cuda kernel libraries are built, delete the exe
-# to force swift build to relink
-if ($ENV{SWIFTRT_PLATFORM} MATCHES "cuda")
-        add_custom_command(TARGET ${SWIFTRT_CUDA_LIB_NAME} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E remove ${TARGET_DIR}/SwiftRTPackageTests.xctest)
+add_subdirectory(Sources)
+if(BUILD_TESTING)
+  add_subdirectory(Tests)
 endif()

--- a/Modules/SwiftRTCuda/CMakeLists.txt
+++ b/Modules/SwiftRTCuda/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(SwiftRTCuda STATIC
+  delayStream.cu
+  fillOps.cu
+  mathOps.cu
+  randomOps.cu)
+target_compile_options(SwiftRTCuda PRIVATE
+  -allow-unsupported-compiler
+  --std c++17
+  --expt-relaxed-constexpr
+  -Wno-deprecated-gpu-targets
+  -gencode arch=compute_75,code=sm_75
+  --compiler-options -fPIC)
+target_include_directories(SwiftRTCuda PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Modules/SwiftRTCuda/CMakeLists.txt
+++ b/Modules/SwiftRTCuda/CMakeLists.txt
@@ -11,7 +11,11 @@ target_compile_options(SwiftRTCuda PRIVATE
   --std c++17
   --expt-relaxed-constexpr
   -Wno-deprecated-gpu-targets
-  -gencode arch=compute_75,code=sm_75
+  -gencode=arch=compute_60,code=sm_60
+  -gencode=arch=compute_70,code=sm_70
+  -gencode=arch=compute_75,code=sm_75
   --compiler-options -fPIC)
 target_include_directories(SwiftRTCuda PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_property(TARGET SwiftRTCuda PROPERTY CUDA_ARCHITECTURES 60 70 75)

--- a/Modules/SwiftRTCuda/CMakeLists.txt
+++ b/Modules/SwiftRTCuda/CMakeLists.txt
@@ -11,11 +11,6 @@ target_compile_options(SwiftRTCuda PRIVATE
   --std c++17
   --expt-relaxed-constexpr
   -Wno-deprecated-gpu-targets
-  -gencode=arch=compute_60,code=sm_60
-  -gencode=arch=compute_70,code=sm_70
-  -gencode=arch=compute_75,code=sm_75
   --compiler-options -fPIC)
 target_include_directories(SwiftRTCuda PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR})
-
-set_property(TARGET SwiftRTCuda PROPERTY CUDA_ARCHITECTURES 60 70 75)

--- a/Modules/SwiftRTCuda/CMakeLists.txt
+++ b/Modules/SwiftRTCuda/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_library(SwiftRTCuda STATIC
+  compare_ops.cu
   delayStream.cu
-  fillOps.cu
-  mathOps.cu
-  randomOps.cu)
+  fill_ops.cu
+  math_ops.cu
+  random_ops.cu
+  reduce_ops.cu
+  specialized_ops.cu)
 target_compile_options(SwiftRTCuda PRIVATE
   -allow-unsupported-compiler
   --std c++17

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(SwiftRTCore)
+add_subdirectory(SwiftRTLayers)
+add_subdirectory(SwiftRT)

--- a/Sources/SwiftRT/CMakeLists.txt
+++ b/Sources/SwiftRT/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(SwiftRT
+  SwiftRT.swift)
+target_link_libraries(SwiftRT PUBLIC
+  SwiftRTCore
+  SwiftRTLayers)

--- a/Sources/SwiftRTCore/CMakeLists.txt
+++ b/Sources/SwiftRTCore/CMakeLists.txt
@@ -1,0 +1,94 @@
+add_library(SwiftRTCore
+  common/ElapsedTime.swift
+  common/HashingUtilities.swift
+  common/Helpers.swift
+  common/Log.swift
+  common/StdlibExtensions.swift
+
+  numpy/RankFunctions.swift
+  numpy/array.swift
+  numpy/arrayInit.swift
+  numpy/eye.swift
+
+  operators/AlgebraicField.swift
+  operators/Comparative.swift
+  operators/DifferentialOperators.swift
+  operators/Fill.swift
+  operators/Gather.swift
+  operators/Infix.swift
+  operators/Kernel.swift
+  operators/Math.swift
+  operators/Matmul.swift
+  operators/Reductions.swift
+
+  platform/common/BFloat16.swift
+  platform/common/ComplexExtensions.swift
+  platform/common/DeviceQueue.swift
+  platform/common/DiscreteStorage.swift
+  platform/common/ExecutionPlanner.swift
+  platform/common/Float16.swift
+  platform/common/FunctionProperties.swift
+  platform/common/Platform.swift
+  platform/common/StorageBuffer.swift
+  platform/common/StorageElement.swift
+  platform/common/pmap.swift
+
+  platform/cpu/device/CpuDevice.swift
+  platform/cpu/device/CpuEvent.swift
+  platform/cpu/device/CpuPlatform.swift
+  platform/cpu/device/CpuQueue.swift
+  platform/cpu/device/CpuStorage.swift
+
+  platform/cpu/functions/CpuConvolution.swift
+  platform/cpu/functions/CpuFill.swift
+  platform/cpu/functions/CpuMapOps.swift
+  platform/cpu/functions/CpuMath.swift
+  platform/cpu/functions/CpuMatmul.swift
+  platform/cpu/functions/CpuReductions.swift
+
+  random/RandomGenerators.swift
+  random/RandomInit.swift
+  random/RandomSeedState.swift
+
+  tensor/Description.swift
+  tensor/Ranges.swift
+  tensor/Shape.swift
+  tensor/Subscripts.swift
+  tensor/SubscriptsUnbound.swift
+  tensor/Tensor.swift
+  tensor/TensorInit.swift
+  tensor/VectorElement.swift)
+if(SWIFTRT_ENABLE_CUDA)
+  target_sources(SwiftRTCore PRIVATE
+    platform/cuda/cublaslt/MatmulAlgorithm.swift
+    platform/cuda/cublaslt/MatmulAlgorithmHeuristics.swift
+    platform/cuda/cublaslt/MatmulAlgorithmSearch.swift
+    platform/cuda/cublaslt/MatmulOperation.swift
+    platform/cuda/cublaslt/MatmulPreferences.swift
+    platform/cuda/cublaslt/MatrixLayout.swift
+    platform/cuda/cublaslt/MatrixTransform.swift
+
+    platform/cuda/device/CudaDevice.swift
+    platform/cuda/device/CudaEvent.swift
+    platform/cuda/device/CudaExtensions.swift
+    platform/cuda/device/CudaPlatform.swift
+    platform/cuda/device/CudaQueue.swift
+
+    platform/cuda/functions/CudaCompare.swift
+    platform/cuda/functions/CudaFill.swift
+    platform/cuda/functions/CudaMath.swift
+    platform/cuda/functions/CudaMathGen.swift
+    platform/cuda/functions/CudaMatmul.swift
+    platform/cuda/functions/CudaReductions.swift
+
+    platform/cuda/layers/CudaActivation.swift
+    platform/cuda/layers/CudaConvolution.swift)
+  target_link_libraries(SwiftRTCore PUBLIC
+    SwiftRTCuda)
+endif()
+set_target_properties(SwiftRTCore PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_libraries(SwiftRTCore PUBLIC
+  $<$<AND:$<BOOL:dispatch_FOUND>,$<NOT:$<PLATFORM_ID:Darwin>>>:dispatch>
+  $<$<AND:$<BOOL:Foundation_FOUND>,$<NOT:$<PLATFORM_ID:Darwin>>>:Foundation>
+  Numerics)

--- a/Sources/SwiftRTLayers/CMakeLists.txt
+++ b/Sources/SwiftRTLayers/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(SwiftRTLayers
+  Convolution.swift
+  Dense.swift
+  Embedding.swift
+  Layer.swift
+  Normalization.swift
+  ParameterInitializer.swift
+  Recurrent.swift
+  common/BijectiveDictionary.swift)
+set_target_properties(SwiftRTLayers PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_libraries(SwiftRTLayers PUBLIC
+  SwiftRTCore)

--- a/Tests/BenchmarkTests/CMakeLists.txt
+++ b/Tests/BenchmarkTests/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+add_library(BenchmarkTests
+  XCTestManifests.swift
+  test_Fractals.swift)
+target_link_libraries(BenchmarkTests PUBLIC
+  $<$<AND:$<BOOL:Foundation_FOUND>,$<NOT:$<PLATFORM_ID:Darwin>>>:Foundation>
+  $<$<BOOL:XCTest_Found>:XCTest>
+  SwiftRT)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+find_package(XCTest CONFIG QUIET)
+
+add_subdirectory(BenchmarkTests)
+add_subdirectory(SwiftRTCoreTests)
+add_subdirectory(SwiftRTLayerTests)
+
+add_executable(SwiftRTTestRunner
+  LinuxMain.swift)
+target_link_libraries(SwiftRTTestRunner PRIVATE
+  BenchmarkTests
+  SwiftRTCoreTests
+  SwiftRTLayerTests)
+
+add_test(NAME SwiftRTTests
+  COMMAND SwiftRTTestRunner)

--- a/Tests/SwiftRTCoreTests/CMakeLists.txt
+++ b/Tests/SwiftRTCoreTests/CMakeLists.txt
@@ -1,0 +1,22 @@
+
+add_library(SwiftRTCoreTests
+  XCTestManifests.swift
+  test_AlgebraicField.swift
+  test_Async.swift
+  test_Codable.swift
+  test_Comparative.swift
+  test_Initialize.swift
+  test_Math.swift
+  test_PackedElements.swift
+  test_Random.swift
+  test_Reductions.swift
+  test_Shape.swift
+  test_StorageElement.swift
+  test_Subscripting.swift
+  test_VectorElement.swift
+  test_Vectorizing.swift
+  test_arraySyntax.swift)
+target_link_libraries(SwiftRTCoreTests PUBLIC
+  $<$<AND:$<BOOL:Foundation_FOUND>,$<NOT:$<PLATFORM_ID:Darwin>>>:Foundation>
+  $<$<BOOL:XCTest_Found>:XCTest>
+  SwiftRT)

--- a/Tests/SwiftRTLayerTests/CMakeLists.txt
+++ b/Tests/SwiftRTLayerTests/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+add_library(SwiftRTLayerTests
+  TestHelpers.swift
+  XCTestManifests.swift
+  test_Convolution.swift
+  test_Dense.swift
+  test_Recurrent.swift)
+target_link_libraries(SwiftRTLayerTests PUBLIC
+  $<$<AND:$<BOOL:Foundation_FOUND>,$<NOT:$<PLATFORM_ID:Darwin>>>:Foundation>
+  $<$<BOOL:XCTest_Found>:XCTest>
+  SwiftRT
+  SwiftRTLayers)


### PR DESCRIPTION
Adjust the build system to use CMake properly for building the project.
This also modernises the implementation to use the newer CUDA support in
CMake.