### PR TITLE
build: use CMake to control flags for building SwiftRTCuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 if(SWIFTRT_ENABLE_CUDA)
   enable_language(CUDA)
+
+  set(CMAKE_CUDA_STANDARD 17)
+  set(CMAKE_CUDA_STANDARD_REQUIRED YES)
+
   add_subdirectory(Modules/SwiftRTCuda)
 endif()
 

--- a/Modules/SwiftRTCuda/CMakeLists.txt
+++ b/Modules/SwiftRTCuda/CMakeLists.txt
@@ -6,12 +6,13 @@ add_library(SwiftRTCuda STATIC
   random_ops.cu
   reduce_ops.cu
   specialized_ops.cu)
+set_target_properties(SwiftRTCuda PROPERTIES
+  CUDA_SEPARABLE_COMPILATION YES
+  POSITION_INDEPENDENT_CODE YES)
 target_compile_options(SwiftRTCuda PRIVATE
   -allow-unsupported-compiler
-  --std c++17
   --expt-relaxed-constexpr
-  -Wno-deprecated-gpu-targets
-  --compiler-options -fPIC)
+  -Wno-deprecated-gpu-targets)
 target_include_directories(SwiftRTCuda PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR})
 target_precompile_headers(SwiftRTCuda PRIVATE precomp.hpp)


### PR DESCRIPTION
Use the `POSITION_INDEPENDENT` property to pass along `-fPIC`.  Use the
`CMAKE_CUDA_STANDARD` to pass along `-std=c++17`.  This is more
declarative and portable across compilers.