### PR TITLE
SwiftRTCuda: do not vend CUDA as SwiftRTCuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,17 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 if(SWIFTRT_ENABLE_CUDA)
+  enable_language(CXX)
   enable_language(CUDA)
+  find_package(CUDAToolkit REQUIRED)
+  if(CUDAToolkit_FOUND)
+    _CUDAToolkit_find_and_add_import_lib(cudnn)
+  endif()
 
   set(CMAKE_CUDA_STANDARD 17)
   set(CMAKE_CUDA_STANDARD_REQUIRED YES)
 
+  add_subdirectory(Sources/CCUDA)
   add_subdirectory(Modules/SwiftRTCuda)
 endif()
 

--- a/Modules/SwiftRTCuda/CMakeLists.txt
+++ b/Modules/SwiftRTCuda/CMakeLists.txt
@@ -15,4 +15,6 @@ target_compile_options(SwiftRTCuda PRIVATE
   -Wno-deprecated-gpu-targets)
 target_include_directories(SwiftRTCuda PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(SwiftRTCuda PUBLIC
+  CCUDA)
 target_precompile_headers(SwiftRTCuda PRIVATE precomp.hpp)

--- a/Modules/SwiftRTCuda/SwiftRTCuda.h
+++ b/Modules/SwiftRTCuda/SwiftRTCuda.h
@@ -14,8 +14,10 @@
 // limitations under the License.
 //
 #pragma once
-#include <cublasLt.h>
-#include <cuda_runtime.h>
-#include <cudnn.h>
-#include <curand.h>
-#include "srt_cuda_api.h"
+
+// this is an umbrella header
+#include "math_c.h"
+#include "compare_c.h"
+#include "fill_c.h"
+#include "reduce_c.h"
+#include "specialized_c.h"

--- a/Sources/CCUDA/CMakeLists.txt
+++ b/Sources/CCUDA/CMakeLists.txt
@@ -1,0 +1,14 @@
+configure_file(include/module.modulemap.in module.modulemap @ONLY)
+
+# NOTE: we ignore shim.c as that is specifically for the benefit of Swift
+# Package Manager.
+add_library(CCUDA INTERFACE)
+target_include_directories(CCUDA INTERFACE
+  ${CMAKE_CURRENT_BINARY_DIR})
+target_link_directories(CCUDA INTERFACE
+  ${CUDAToolkit_LIBRARY_DIR})
+target_link_libraries(CCUDA INTERFACE
+  CUDA::cublasLt
+  CUDA::cudart
+  CUDA::cudnn
+  CUDA::curand)

--- a/Sources/CCUDA/include/module.modulemap.in
+++ b/Sources/CCUDA/include/module.modulemap.in
@@ -1,0 +1,20 @@
+
+module CCUDA [system] {
+  header "@CUDAToolkit_INCLUDE_DIRS@/cuda_runtime.h"
+  export *
+
+  module BLAS {
+    header "@CUDAToolkit_INCLUDE_DIRS@/cublasLt.h"
+    export *
+  }
+
+  module DNN {
+    header "@CUDAToolkit_INCLUDE_DIRS@/cudnn.h"
+    export *
+  }
+
+  module RAND {
+    header "@CUDAToolkit_INCLUDE_DIRS@/curand.h"
+    export *
+  }
+}

--- a/Sources/CCUDA/shim.c
+++ b/Sources/CCUDA/shim.c
@@ -13,11 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
 
-// this is an umbrella header
-#include "math_c.h"
-#include "compare_c.h"
-#include "fill_c.h"
-#include "reduce_c.h"
-#include "specialized_c.h"
+// Add an "anchor" - C standards require at least one declaration or definition
+// in a translation unit, so provide an unresolved symbol that will be
+// discarded.
+extern unsigned int CCUDA;

--- a/Sources/SwiftRTCore/CMakeLists.txt
+++ b/Sources/SwiftRTCore/CMakeLists.txt
@@ -85,6 +85,8 @@ if(SWIFTRT_ENABLE_CUDA)
     platform/cuda/layers/CudaConvolution.swift)
   target_link_libraries(SwiftRTCore PRIVATE
     SwiftRTCuda)
+  target_link_libraries(SwiftRTCore PUBLIC
+    CCUDA)
 endif()
 set_target_properties(SwiftRTCore PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/SwiftRTCore/platform/common/StorageElement.swift
+++ b/Sources/SwiftRTCore/platform/common/StorageElement.swift
@@ -17,6 +17,7 @@ import Foundation
 import Numerics
 
 #if canImport(SwiftRTCuda)
+import CCUDA
 import SwiftRTCuda
 #endif
 


### PR DESCRIPTION
CUDA is a separate library, not vended by SwiftRTCuda, although it does
re-export it for users.  Split the CUDA into a local module definition
(which is SPM friendly) and build atop of that.  This allows the removal
of the superfluous `srt_cuda_api.h` header, which is now inlined into
`SwiftRTCuda.h` as an umbrella header.

The only issue that remains to be solved here is the modulemap
redistribution - the modulemap contains build specific configuration
(namely the location of the CUDA headers).  As the modulemap is not
installed next to the headers, it is not possible to use a path relative
location and modulemaps are currently not relocatable.