### PR TITLE
Enabling SwiftRT to build using official Swift toolchains

### DIFF
--- a/Sources/SwiftRTCore/common/StdlibExtensions.swift
+++ b/Sources/SwiftRTCore/common/StdlibExtensions.swift
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _Differentiation
+
 extension Array.DifferentiableView:
     BidirectionalCollection,
     Collection,

--- a/Sources/SwiftRTCore/numpy/RankFunctions.swift
+++ b/Sources/SwiftRTCore/numpy/RankFunctions.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Foundation
 
 // gyb utility docs

--- a/Sources/SwiftRTCore/numpy/RankFunctions.swift.gyb
+++ b/Sources/SwiftRTCore/numpy/RankFunctions.swift.gyb
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Foundation
 
 // gyb utility docs

--- a/Sources/SwiftRTCore/operators/AlgebraicField.swift
+++ b/Sources/SwiftRTCore/operators/AlgebraicField.swift
@@ -211,6 +211,11 @@ extension Tensor where Element: AdditiveArithmetic {
     return out
 }
 
+// TODO: Remove this when we find a better way to deal with PointwiseMultiplicative.
+#if !canImport(TensorFlow)
+infix operator .*
+#endif
+
 //==============================================================================
 /// mul
 extension Tensor where Element: Numeric {

--- a/Sources/SwiftRTCore/operators/AlgebraicField.swift
+++ b/Sources/SwiftRTCore/operators/AlgebraicField.swift
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import _Differentiation
 import Numerics
 
 extension Tensor where Element: AdditiveArithmetic {

--- a/Sources/SwiftRTCore/operators/Comparative.swift
+++ b/Sources/SwiftRTCore/operators/Comparative.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Numerics
 
 //==============================================================================

--- a/Sources/SwiftRTCore/operators/Fill.swift
+++ b/Sources/SwiftRTCore/operators/Fill.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Foundation
 
 //==============================================================================

--- a/Sources/SwiftRTCore/operators/Gather.swift
+++ b/Sources/SwiftRTCore/operators/Gather.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Foundation
 
 //==============================================================================

--- a/Sources/SwiftRTCore/operators/Math.swift
+++ b/Sources/SwiftRTCore/operators/Math.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Numerics
 
 //==============================================================================

--- a/Sources/SwiftRTCore/operators/Matmul.swift
+++ b/Sources/SwiftRTCore/operators/Matmul.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Foundation
 
 //==============================================================================

--- a/Sources/SwiftRTCore/operators/Reductions.swift
+++ b/Sources/SwiftRTCore/operators/Reductions.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Numerics
 
 //==============================================================================

--- a/Sources/SwiftRTCore/tensor/Subscripts.swift
+++ b/Sources/SwiftRTCore/tensor/Subscripts.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Foundation
 
 // gyb utility docs

--- a/Sources/SwiftRTCore/tensor/Subscripts.swift.gyb
+++ b/Sources/SwiftRTCore/tensor/Subscripts.swift.gyb
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Foundation
 
 // gyb utility docs

--- a/Sources/SwiftRTCore/tensor/SubscriptsUnbound.swift
+++ b/Sources/SwiftRTCore/tensor/SubscriptsUnbound.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Foundation
 
 /// `Tensor Subscript Behavior`

--- a/Sources/SwiftRTCore/tensor/Tensor.swift
+++ b/Sources/SwiftRTCore/tensor/Tensor.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Foundation
 import Numerics
 

--- a/Sources/SwiftRTCore/tensor/TensorInit.swift
+++ b/Sources/SwiftRTCore/tensor/TensorInit.swift
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import Foundation
 import Numerics
 

--- a/Sources/SwiftRTLayers/Dense.swift
+++ b/Sources/SwiftRTLayers/Dense.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 import SwiftRTCore
+#if canImport(TensorFlow)
 
 //==============================================================================
 ///
@@ -94,3 +95,4 @@ public extension Dense where S == Shape3 {
 //            activation: activation)
 //    }
 //}
+#endif

--- a/Sources/SwiftRTLayers/Embedding.swift
+++ b/Sources/SwiftRTLayers/Embedding.swift
@@ -15,6 +15,8 @@
 //
 import SwiftRTCore
 
+#if canImport(TensorFlow)
+
 //==============================================================================
 /// Embedding
 public struct Embedding<Element> : Module
@@ -61,3 +63,5 @@ where Element: StorageElement,
         embeddings.gathering(indices: input)
     }
 }
+
+#endif

--- a/Sources/SwiftRTLayers/Layer.swift
+++ b/Sources/SwiftRTLayers/Layer.swift
@@ -13,8 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+import _Differentiation
 import SwiftRTCore
-
+#if canImport(TensorFlow)
 // Note: `Module` and `Layer` protocol definitions are adapted and simplified from:
 // https://github.com/tensorflow/swift-apis/blob/master/Sources/TensorFlow/Layer.swift
 
@@ -129,3 +130,5 @@ public final class Parameter<S: TensorShape, E: StorageElement> {
         self.value = value
     }
 }
+
+#endif

--- a/Sources/SwiftRTLayers/Recurrent.swift
+++ b/Sources/SwiftRTLayers/Recurrent.swift
@@ -17,6 +17,8 @@ import Foundation
 import SwiftRTCore
 import Numerics
 
+#if canImport(TensorFlow)
+
 //==============================================================================
 /// RNNCellInput
 /// An input to a recurrent neural network
@@ -457,3 +459,5 @@ public typealias LSTM<Element> = RecurrentLayer<LSTMCell<Element>>
 public typealias GRU<Element> = RecurrentLayer<GRUCell<Element>>
     where Element: StorageElement,
           Element.Value: StorageElement & Real & BinaryFloatingPoint & DifferentiableNumeric
+
+#endif

--- a/Tests/SwiftRTCoreTests/test_AlgebraicField.swift
+++ b/Tests/SwiftRTCoreTests/test_AlgebraicField.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 import XCTest
+import _Differentiation
 import Foundation
 import SwiftRT
 import Numerics

--- a/Tests/SwiftRTCoreTests/test_Comparative.swift
+++ b/Tests/SwiftRTCoreTests/test_Comparative.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 import XCTest
+import _Differentiation
 import Foundation
 import SwiftRT
 import Numerics

--- a/Tests/SwiftRTCoreTests/test_Initialize.swift
+++ b/Tests/SwiftRTCoreTests/test_Initialize.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 import XCTest
+import _Differentiation
 import Foundation
 import SwiftRT
 import Numerics

--- a/Tests/SwiftRTCoreTests/test_Math.swift
+++ b/Tests/SwiftRTCoreTests/test_Math.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 import XCTest
+import _Differentiation
 import Foundation
 import SwiftRT
 

--- a/Tests/SwiftRTCoreTests/test_Reductions.swift
+++ b/Tests/SwiftRTCoreTests/test_Reductions.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 import XCTest
+import _Differentiation
 import Foundation
 import SwiftRT
 

--- a/Tests/SwiftRTCoreTests/test_Shape.swift
+++ b/Tests/SwiftRTCoreTests/test_Shape.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 import XCTest
+import _Differentiation
 import Foundation
 import SwiftRT
 

--- a/Tests/SwiftRTCoreTests/test_Subscripting.swift
+++ b/Tests/SwiftRTCoreTests/test_Subscripting.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 import XCTest
+import _Differentiation
 import Foundation
 import SwiftRT
 

--- a/Tests/SwiftRTLayerTests/test_Recurrent.swift
+++ b/Tests/SwiftRTLayerTests/test_Recurrent.swift
@@ -25,6 +25,7 @@ class test_Recurrent: XCTestCase {
 
     //--------------------------------------------------------------------------
     func test_Embedding() {
+        #if canImport(TensorFlow)
         let vocabSize = 4
         let encoder = Embedding<Float>(
                 vocabularySize: vocabSize,
@@ -38,6 +39,7 @@ class test_Recurrent: XCTestCase {
             [3.0, 4.0, 5.0],
             [9.0, 10.0, 11.0]
         ])
+        #endif
     }
     
     //--------------------------------------------------------------------------


### PR DESCRIPTION
This inserts `_Differentation` imports where necessary to enable the upstreamed automatic differentiation support in mainline Swift toolchains. For now, it guards anything that needs KeyPathIterable in an `if canImport(TensorFlow)` to selectively build that only when using a Swift for TensorFlow toolchain, until we can find a more general replacement. It also adds a quick workaround for a PointwiseMultiplicative definition present in the Swift for TensorFlow toolchain.

With these changes, SwiftRT and swiftrt-models can now build using either a stock Swift 5.3 toolchain or a Swift for TensorFlow toolchain.