### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,5 +55,6 @@ let package = Package(
             name: "SwiftRTLayerTests",
             dependencies: ["SwiftRT"],
             exclude: ["CMakeLists.txt"]),
-    ]
+    ],
+    cxxLanguageStandard: .cxx1z
 )


### PR DESCRIPTION
Enable C++1z (aka C++17) as the default C++ standard in SwiftRT.  This is primarily used in the CUDA path.