### PR TITLE
SwiftRTCore: remove stray `(`

### DIFF
--- a/Sources/SwiftRTCore/differentiable/ComparativeDerivatives.swift
+++ b/Sources/SwiftRTCore/differentiable/ComparativeDerivatives.swift
@@ -63,7 +63,7 @@ import _Differentiation
   _ lhs: Tensor<S, E>,
   _ rhs: E.Value
 ) -> (
-  value: Tensor<S, E>, pullback: (Tensor<S, E>) -> Tensor<S, E>)
+  value: Tensor<S, E>, pullback: (Tensor<S, E>) -> Tensor<S, E>
 ) where E.Value: Differentiable & Numeric & Comparable {
   let value = max(lhs, rhs)
   return (


### PR DESCRIPTION
This would fail to compile due the invalid syntax.