### PR TITLE
Fix building against Swift.org toolchains

### DIFF
--- a/Sources/SwiftRTCore/differentiable/ComparativeDerivatives.swift
+++ b/Sources/SwiftRTCore/differentiable/ComparativeDerivatives.swift
@@ -26,7 +26,7 @@ import _Differentiation
   _ rhs: Tensor<S, E>
 ) -> (
   value: Tensor<S, E>, pullback: (Tensor<S, E>) -> (Tensor<S, E>, Tensor<S, E>)
-) where E.Value: Differentiable & Numeric & Comparable {
+) where E.Value: DifferentiableNumeric & Comparable {
   (
     value: min(lhs, rhs),
     {
@@ -45,7 +45,7 @@ import _Differentiation
   _ rhs: E.Value
 ) -> (
   value: Tensor<S, E>, pullback: (Tensor<S, E>) -> (Tensor<S, E>, E.Value)
-) where E.Value: Differentiable & Numeric & Comparable {
+) where E.Value: DifferentiableNumeric & Comparable {
   let value = min(lhs, rhs)
   return (
     value,
@@ -64,7 +64,7 @@ import _Differentiation
   _ rhs: E.Value
 ) -> (
   value: Tensor<S, E>, pullback: (Tensor<S, E>) -> Tensor<S, E>
-) where E.Value: Differentiable & Numeric & Comparable {
+) where E.Value: DifferentiableNumeric & Comparable {
   let value = max(lhs, rhs)
   return (
     value,
@@ -86,7 +86,7 @@ import _Differentiation
   _ rhs: Tensor<S, E>
 ) -> (
   value: Tensor<S, E>, pullback: (Tensor<S, E>) -> (Tensor<S, E>, Tensor<S, E>)
-) where E.Value: Differentiable & Numeric & Comparable {
+) where E.Value: DifferentiableNumeric & Comparable {
   (
     value: max(lhs, rhs),
     {
@@ -105,7 +105,7 @@ import _Differentiation
   _ rhs: E.Value
 ) -> (
   value: Tensor<S, E>, pullback: (Tensor<S, E>) -> (Tensor<S, E>, E.Value)
-) where E.Value: Differentiable & Numeric & Comparable {
+) where E.Value: DifferentiableNumeric & Comparable {
   let value = max(lhs, rhs)
   return (
     value,
@@ -124,7 +124,7 @@ import _Differentiation
   _ rhs: E.Value
 ) -> (
   value: Tensor<S, E>, pullback: (Tensor<S, E>) -> Tensor<S, E>
-) where E.Value: Differentiable & Numeric & Comparable {
+) where E.Value: DifferentiableNumeric & Comparable {
   let value = max(lhs, rhs)
   return (
     value,

--- a/Sources/SwiftRTCore/differentiable/FillDerivatives.swift
+++ b/Sources/SwiftRTCore/differentiable/FillDerivatives.swift
@@ -71,7 +71,7 @@ import _Differentiation
   indices: TensorR1<DeviceIndex>,
   axis: Int = 0
 ) -> (value: Tensor<S, E>, pullback: (Tensor<S, E>) -> Tensor<S, E>)
-where E.Value: Differentiable & Numeric {
+where E.Value: DifferentiableNumeric {
   let axis = axis < 0 ? axis + S.rank : axis
   let value = gather(from: tensor, indices: indices, axis: axis)
   let shape = tensor.shape

--- a/Sources/SwiftRTCore/differentiable/MathDerivatives.swift
+++ b/Sources/SwiftRTCore/differentiable/MathDerivatives.swift
@@ -16,6 +16,7 @@
 #if swift(>=5.3) && canImport(_Differentiation)
 
 import _Differentiation
+import Numerics
 
 extension Tensor where Element: DifferentiableNumeric & AdditiveArithmetic {
   //----------------------------------------------------------------------------


### PR DESCRIPTION
This repairs the build for Swift.org toolchains using non-CUDA builds. Using Swift for TensorFlow toolchains still leads to build issues with the Embedding and Recurrent modules, which are only enabled for that toolchain, so that'll need more work.

There are some unrelated CUDA build failures that still need to be addressed for those builds. Additionally, there are some issues with Float16 values in tests that are unrelated to differentiability. There are a couple of differentiability issues in tests that still may need to be addressed, but this gets the core building.